### PR TITLE
OTel Export Concurrency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2956,6 +2956,7 @@ dependencies = [
  "bytes",
  "http",
  "openssl",
+ "opentelemetry",
  "res-azkeyvault",
  "res-mongodb",
  "res-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 axum = { workspace = true, features = ["macros"] }
 bytes.workspace = true
 http.workspace = true
+opentelemetry.workspace = true
 sdk-http.workspace = true
 sdk-otel.workspace = true
 # sdk-otel = { workspace = true, features = ["guest-export"] }

--- a/crates/sdk-otel/src/export/metrics.rs
+++ b/crates/sdk-otel/src/export/metrics.rs
@@ -12,7 +12,7 @@ use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
 
 use crate::generated::wasi::otel::metrics as wasi;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Exporter;
 
 impl Exporter {
@@ -25,7 +25,7 @@ impl Exporter {
 impl PushMetricExporter for Exporter {
     async fn export(&self, metrics: &ResourceMetrics) -> Result<(), OTelSdkError> {
         let metrics: wasi::ResourceMetrics = metrics.into();
-        wit_bindgen::block_on(async move {
+        wit_bindgen::spawn(async move {
             if let Err(e) = wasi::export(metrics).await {
                 tracing::error!("failed to export metrics: {e}");
             }

--- a/crates/sdk-otel/src/export/tracing.rs
+++ b/crates/sdk-otel/src/export/tracing.rs
@@ -8,7 +8,7 @@ use opentelemetry_sdk::trace::SpanData;
 
 use crate::generated::wasi::otel::tracing as wasi;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Exporter;
 
 impl Exporter {
@@ -20,7 +20,7 @@ impl Exporter {
 
 impl opentelemetry_sdk::trace::SpanExporter for Exporter {
     async fn export(&self, batch: Vec<SpanData>) -> Result<(), OTelSdkError> {
-        wit_bindgen::block_on(async move {
+        wit_bindgen::spawn(async move {
             let spans = batch.into_iter().map(Into::into).collect::<Vec<_>>();
             if let Err(e) = wasi::export(spans).await {
                 tracing::error!("failed to export spans: {e}");

--- a/crates/sdk-otel/src/init/metrics.rs
+++ b/crates/sdk-otel/src/init/metrics.rs
@@ -4,7 +4,6 @@ use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 use anyhow::Result;
-use futures::executor::block_on;
 use opentelemetry::global;
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::error::OTelSdkResult;
@@ -61,6 +60,8 @@ impl MetricReader for Reader {
     fn shutdown_with_timeout(&self, _: Duration) -> OTelSdkResult {
         let mut rm = ResourceMetrics::default();
         self.reader.collect(&mut rm)?;
-        block_on(async { self.exporter.export(&rm).await })
+
+        let exporter = Arc::clone(&self.exporter);
+        wit_bindgen::block_on(async move { exporter.export(&rm).await })
     }
 }

--- a/crates/sdk-otel/src/init/tracing.rs
+++ b/crates/sdk-otel/src/init/tracing.rs
@@ -4,7 +4,6 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::Result;
-use futures::executor::block_on;
 use opentelemetry::trace::{SpanContext, TraceContextExt};
 use opentelemetry::{Context, ContextGuard, global, trace as otel};
 use opentelemetry_sdk::Resource;
@@ -76,11 +75,13 @@ impl SpanProcessor for Processor {
             return Ok(());
         }
 
-        block_on(async { self.exporter.export(spans).await })?;
+        let exporter = self.exporter.clone();
+        wit_bindgen::block_on(async move { exporter.export(spans).await })?;
         Ok(())
     }
 
     fn set_resource(&mut self, resource: &Resource) {
+        
         self.exporter.set_resource(resource);
     }
 }

--- a/crates/sdk-otel/src/init/tracing.rs
+++ b/crates/sdk-otel/src/init/tracing.rs
@@ -81,7 +81,6 @@ impl SpanProcessor for Processor {
     }
 
     fn set_resource(&mut self, resource: &Resource) {
-        
         self.exporter.set_resource(resource);
     }
 }


### PR DESCRIPTION
Use `wit_bindgen` instead of Rust `futures` for controlling `block_on` and `spawn` in span and metric exports.