### PR TITLE
Start telemetry early

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ res-mongodb.workspace = true
 res-nats.workspace = true
 runtime.workspace = true
 tokio = { workspace = true, features = ["signal"] }
+tracing.workspace = true
 wasi-blobstore-mdb.workspace = true
 wasi-http.workspace = true
 wasi-keyvalue-nats.workspace = true

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -46,16 +46,6 @@ impl RuntimeBuilder {
         self
     }
 
-    /// Enable or disable telemetry for the runtime.
-    ///
-    /// By default, telemetry is enabled so this method is only required
-    /// to disable telemetry.
-    #[must_use]
-    pub const fn telemetry(mut self, telemetry: bool) -> Self {
-        self.telemetry = telemetry;
-        self
-    }
-
     /// Return the runtime instance
     #[must_use]
     pub fn build(self) -> Runtime {

--- a/src/minimal.rs
+++ b/src/minimal.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, anyhow};
 use res_mongodb::MongoDb;
-use runtime::{AddResource, Cli, Command, Parser, ResourceBuilder, Runtime};
+use runtime::{AddResource, Cli, Command, Parser, ResourceBuilder, RuntimeBuilder};
 use wasi_blobstore_mdb::Blobstore;
 use wasi_http::Http;
 use wasi_otel::Otel;
@@ -10,6 +10,11 @@ async fn main() -> Result<()> {
     let Command::Run { wasm } = Cli::parse().command else {
         return Err(anyhow!("only run command is supported"));
     };
+    let builder = RuntimeBuilder::new(wasm, true);
+    tracing::info!("Tracing initialised, logging available");
+
     let mongodb = MongoDb::new().await?;
-    Runtime::new(wasm).register(Otel).register(Http).register(Blobstore.resource(mongodb)?).await
+    let runtime =
+        builder.register(Otel).register(Http).register(Blobstore.resource(mongodb)?).build();
+    runtime.await
 }

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -2,7 +2,7 @@ use anyhow::{Result, anyhow};
 use res_azkeyvault::AzKeyVault;
 use res_mongodb::MongoDb;
 use res_nats::Nats;
-use runtime::{AddResource, Cli, Command, Parser, ResourceBuilder, Runtime};
+use runtime::{AddResource, Cli, Command, Parser, ResourceBuilder, RuntimeBuilder};
 use wasi_blobstore_mdb::Blobstore;
 use wasi_http::Http;
 use wasi_keyvalue_nats::KeyValue;
@@ -15,15 +15,20 @@ async fn main() -> Result<()> {
     let Command::Run { wasm } = Cli::parse().command else {
         return Err(anyhow!("only run command is supported"));
     };
-    let (mongodb, az_secret, nats) = tokio::join!(MongoDb::new(), AzKeyVault::new(), Nats::new());
-    let nats = nats?;
+    let builder = RuntimeBuilder::new(wasm, true);
+    tracing::info!("Tracing initialised, logging available");
 
-    Runtime::new(wasm)
+    let (mongodb, az_secret, nats) =
+        tokio::try_join!(MongoDb::new(), AzKeyVault::new(), Nats::new())?;
+
+    let runtime = builder
         .register(Otel)
         .register(Http)
-        .register(Blobstore.resource(mongodb?)?)
+        .register(Blobstore.resource(mongodb)?)
         .register(KeyValue.resource(nats.clone())?)
-        .register(Vault.resource(az_secret?)?)
+        .register(Vault.resource(az_secret)?)
         .register(Messaging.resource(nats)?)
-        .await
+        .build();
+
+    runtime.await
 }


### PR DESCRIPTION
Start telemetry earlier so we can see the tracing output from service start ups.