### PR TITLE
Blobstore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,6 +2144,7 @@ dependencies = [
  "http",
  "http-body",
  "omnia-guest-macro",
+ "omnia-wasi-blobstore",
  "omnia-wasi-config",
  "omnia-wasi-http",
  "omnia-wasi-identity",

--- a/clippy.toml
+++ b/clippy.toml
@@ -11,6 +11,7 @@ doc-valid-idents = [
 
 allowed-duplicate-crates = [
   "core-foundation",
+  "jni-sys",
   "cpufeatures",
   "embedded-io",
   "foldhash",

--- a/crates/omnia-sdk/Cargo.toml
+++ b/crates/omnia-sdk/Cargo.toml
@@ -28,6 +28,7 @@ tracing.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 omnia-guest-macro.workspace = true
+omnia-wasi-blobstore.workspace = true
 omnia-wasi-config.workspace = true
 omnia-wasi-http.workspace = true
 omnia-wasi-identity.workspace = true

--- a/crates/omnia-sdk/src/capabilities.rs
+++ b/crates/omnia-sdk/src/capabilities.rs
@@ -635,9 +635,7 @@ pub trait BlobStore: Send + Sync {
             let ctr = blobstore::get_container(container.to_string())
                 .await
                 .map_err(|e| anyhow!("opening container: {e}"))?;
-            ctr.delete_objects(&names)
-                .await
-                .map_err(|e| anyhow!("deleting objects: {e}"))
+            ctr.delete_objects(&names).await.map_err(|e| anyhow!("deleting objects: {e}"))
         }
     }
 
@@ -730,9 +728,7 @@ pub trait BlobStore: Send + Sync {
                 container: dest_container.to_string(),
                 object: dest_name.to_string(),
             };
-            blobstore::copy_object(&src, &dest)
-                .await
-                .map_err(|e| anyhow!("copying object: {e}"))
+            blobstore::copy_object(&src, &dest).await.map_err(|e| anyhow!("copying object: {e}"))
         }
     }
 
@@ -756,9 +752,7 @@ pub trait BlobStore: Send + Sync {
                 container: dest_container.to_string(),
                 object: dest_name.to_string(),
             };
-            blobstore::move_object(&src, &dest)
-                .await
-                .map_err(|e| anyhow!("moving object: {e}"))
+            blobstore::move_object(&src, &dest).await.map_err(|e| anyhow!("moving object: {e}"))
         }
     }
 }

--- a/crates/omnia-sdk/src/capabilities.rs
+++ b/crates/omnia-sdk/src/capabilities.rs
@@ -333,3 +333,143 @@ pub trait Broadcast: Send + Sync {
         }
     }
 }
+
+/// Binary large object storage (WASI Blobstore).
+///
+/// Default WASM implementations delegate to `wasi:blobstore` via
+/// `omnia-wasi-blobstore`.
+pub trait BlobStore: Send + Sync {
+    /// Retrieve an object's data from a container.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn get(
+        &self, container: &str, name: &str,
+    ) -> impl Future<Output = Result<Option<Vec<u8>>>> + Send;
+
+    /// Store an object in a container.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn put(
+        &self, container: &str, name: &str, data: &[u8],
+    ) -> impl Future<Output = Result<()>> + Send;
+
+    /// Delete an object from a container.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn delete(&self, container: &str, name: &str) -> impl Future<Output = Result<()>> + Send;
+
+    /// Check whether an object exists in a container.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn has(&self, container: &str, name: &str) -> impl Future<Output = Result<bool>> + Send;
+
+    /// List all object names in a container.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn list(&self, container: &str) -> impl Future<Output = Result<Vec<String>>> + Send;
+
+    /// Retrieve an object's data from a container.
+    #[cfg(target_arch = "wasm32")]
+    fn get(
+        &self, container: &str, name: &str,
+    ) -> impl Future<Output = Result<Option<Vec<u8>>>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+        use omnia_wasi_blobstore::types::IncomingValue;
+
+        async move {
+            let ctr = blobstore::get_container(container.to_string())
+                .await
+                .map_err(|e| anyhow!("opening container: {e}"))?;
+            if !ctr
+                .has_object(name.to_string())
+                .await
+                .map_err(|e| anyhow!("checking object existence: {e}"))?
+            {
+                return Ok(None);
+            }
+            let incoming = ctr
+                .get_data(name.to_string(), 0, u64::MAX)
+                .await
+                .map_err(|e| anyhow!("reading object: {e}"))?;
+            let data = IncomingValue::incoming_value_consume_sync(incoming)
+                .map_err(|e| anyhow!("consuming incoming value: {e}"))?;
+            Ok(Some(data))
+        }
+    }
+
+    /// Store an object in a container.
+    #[cfg(target_arch = "wasm32")]
+    fn put(
+        &self, container: &str, name: &str, data: &[u8],
+    ) -> impl Future<Output = Result<()>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+        use omnia_wasi_blobstore::types::OutgoingValue;
+
+        async move {
+            let ctr = blobstore::get_container(container.to_string())
+                .await
+                .map_err(|e| anyhow!("opening container: {e}"))?;
+            let outgoing = OutgoingValue::new_outgoing_value();
+            {
+                let body = outgoing
+                    .outgoing_value_write_body()
+                    .await
+                    .map_err(|e| anyhow!("getting write body: {e}"))?;
+                body.blocking_write_and_flush(data).map_err(|e| anyhow!("writing data: {e}"))?;
+            }
+            ctr.write_data(name.to_string(), &outgoing)
+                .await
+                .map_err(|e| anyhow!("writing object: {e}"))?;
+            OutgoingValue::finish(outgoing).map_err(|e| anyhow!("finishing write: {e}"))?;
+            Ok(())
+        }
+    }
+
+    /// Delete an object from a container.
+    #[cfg(target_arch = "wasm32")]
+    fn delete(&self, container: &str, name: &str) -> impl Future<Output = Result<()>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+
+        async move {
+            let ctr = blobstore::get_container(container.to_string())
+                .await
+                .map_err(|e| anyhow!("opening container: {e}"))?;
+            ctr.delete_object(name.to_string()).await.map_err(|e| anyhow!("deleting object: {e}"))
+        }
+    }
+
+    /// Check whether an object exists in a container.
+    #[cfg(target_arch = "wasm32")]
+    fn has(&self, container: &str, name: &str) -> impl Future<Output = Result<bool>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+
+        async move {
+            let ctr = blobstore::get_container(container.to_string())
+                .await
+                .map_err(|e| anyhow!("opening container: {e}"))?;
+            ctr.has_object(name.to_string())
+                .await
+                .map_err(|e| anyhow!("checking object existence: {e}"))
+        }
+    }
+
+    /// List all object names in a container.
+    #[cfg(target_arch = "wasm32")]
+    fn list(&self, container: &str) -> impl Future<Output = Result<Vec<String>>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+
+        async move {
+            let ctr = blobstore::get_container(container.to_string())
+                .await
+                .map_err(|e| anyhow!("opening container: {e}"))?;
+            let stream = ctr.list_objects().await.map_err(|e| anyhow!("listing objects: {e}"))?;
+            let mut names = Vec::new();
+            loop {
+                let (batch, done) = stream
+                    .read_stream_object_names(100)
+                    .await
+                    .map_err(|e| anyhow!("reading object names: {e}"))?;
+                names.extend(batch);
+                if done {
+                    break;
+                }
+            }
+            Ok(names)
+        }
+    }
+}

--- a/crates/omnia-sdk/src/capabilities.rs
+++ b/crates/omnia-sdk/src/capabilities.rs
@@ -334,11 +334,41 @@ pub trait Broadcast: Send + Sync {
     }
 }
 
+/// Metadata for a blobstore container.
+///
+/// Mirrors the `container-metadata` record from `wasi:blobstore/types`.
+#[derive(Clone, Debug)]
+pub struct ContainerMetadata {
+    /// The container's name.
+    pub name: String,
+    /// Seconds since Unix epoch when the container was created.
+    pub created_at: u64,
+}
+
+/// Metadata for an object in a blobstore container.
+///
+/// Mirrors the `object-metadata` record from `wasi:blobstore/types`.
+#[derive(Clone, Debug)]
+pub struct ObjectMetadata {
+    /// The object's name.
+    pub name: String,
+    /// The object's parent container.
+    pub container: String,
+    /// Seconds since Unix epoch when the object was created.
+    pub created_at: u64,
+    /// Size of the object in bytes.
+    pub size: u64,
+}
+
 /// Binary large object storage (WASI Blobstore).
 ///
 /// Default WASM implementations delegate to `wasi:blobstore` via
 /// `omnia-wasi-blobstore`.
 pub trait BlobStore: Send + Sync {
+    // ------------------------------------------------------------------
+    // Object operations
+    // ------------------------------------------------------------------
+
     /// Retrieve an object's data from a container.
     #[cfg(not(target_arch = "wasm32"))]
     fn get(
@@ -362,6 +392,78 @@ pub trait BlobStore: Send + Sync {
     /// List all object names in a container.
     #[cfg(not(target_arch = "wasm32"))]
     fn list(&self, container: &str) -> impl Future<Output = Result<Vec<String>>> + Send;
+
+    /// Retrieve a byte range of an object's data.
+    ///
+    /// Both `start` and `end` offsets are inclusive.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn get_range(
+        &self, container: &str, name: &str, start: u64, end: u64,
+    ) -> impl Future<Output = Result<Vec<u8>>> + Send;
+
+    /// Return metadata for an object.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn object_info(
+        &self, container: &str, name: &str,
+    ) -> impl Future<Output = Result<ObjectMetadata>> + Send;
+
+    /// Delete multiple objects from a container.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn delete_objects(
+        &self, container: &str, names: &[String],
+    ) -> impl Future<Output = Result<()>> + Send;
+
+    /// Remove all objects from a container, leaving it empty.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn clear(&self, container: &str) -> impl Future<Output = Result<()>> + Send;
+
+    // ------------------------------------------------------------------
+    // Container management
+    // ------------------------------------------------------------------
+
+    /// Create a new empty container.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn create_container(&self, name: &str) -> impl Future<Output = Result<()>> + Send;
+
+    /// Delete a container and all objects within it.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn delete_container(&self, name: &str) -> impl Future<Output = Result<()>> + Send;
+
+    /// Check whether a container exists.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn container_exists(&self, name: &str) -> impl Future<Output = Result<bool>> + Send;
+
+    /// Return metadata for a container.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn container_info(
+        &self, container: &str,
+    ) -> impl Future<Output = Result<ContainerMetadata>> + Send;
+
+    // ------------------------------------------------------------------
+    // Cross-container operations
+    // ------------------------------------------------------------------
+
+    /// Copy an object to the same or a different container.
+    ///
+    /// Overwrites the destination object if it already exists. Returns an
+    /// error if the destination container does not exist.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn copy_object(
+        &self, src_container: &str, src_name: &str, dest_container: &str, dest_name: &str,
+    ) -> impl Future<Output = Result<()>> + Send;
+
+    /// Move or rename an object to the same or a different container.
+    ///
+    /// Overwrites the destination object if it already exists. Returns an
+    /// error if the destination container does not exist.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn move_object(
+        &self, src_container: &str, src_name: &str, dest_container: &str, dest_name: &str,
+    ) -> impl Future<Output = Result<()>> + Send;
+
+    // ------------------------------------------------------------------
+    // WASM default implementations
+    // ------------------------------------------------------------------
 
     /// Retrieve an object's data from a container.
     #[cfg(target_arch = "wasm32")]
@@ -470,6 +572,193 @@ pub trait BlobStore: Send + Sync {
                 }
             }
             Ok(names)
+        }
+    }
+
+    /// Retrieve a byte range of an object's data.
+    ///
+    /// Both `start` and `end` offsets are inclusive.
+    #[cfg(target_arch = "wasm32")]
+    fn get_range(
+        &self, container: &str, name: &str, start: u64, end: u64,
+    ) -> impl Future<Output = Result<Vec<u8>>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+        use omnia_wasi_blobstore::types::IncomingValue;
+
+        async move {
+            let ctr = blobstore::get_container(container.to_string())
+                .await
+                .map_err(|e| anyhow!("opening container: {e}"))?;
+            let incoming = ctr
+                .get_data(name.to_string(), start, end)
+                .await
+                .map_err(|e| anyhow!("reading object range: {e}"))?;
+            let data = IncomingValue::incoming_value_consume_sync(incoming)
+                .map_err(|e| anyhow!("consuming incoming value: {e}"))?;
+            Ok(data)
+        }
+    }
+
+    /// Return metadata for an object.
+    #[cfg(target_arch = "wasm32")]
+    fn object_info(
+        &self, container: &str, name: &str,
+    ) -> impl Future<Output = Result<ObjectMetadata>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+
+        async move {
+            let ctr = blobstore::get_container(container.to_string())
+                .await
+                .map_err(|e| anyhow!("opening container: {e}"))?;
+            let info = ctr
+                .object_info(name.to_string())
+                .await
+                .map_err(|e| anyhow!("getting object info: {e}"))?;
+            Ok(ObjectMetadata {
+                name: info.name,
+                container: info.container,
+                created_at: info.created_at,
+                size: info.size,
+            })
+        }
+    }
+
+    /// Delete multiple objects from a container.
+    #[cfg(target_arch = "wasm32")]
+    fn delete_objects(
+        &self, container: &str, names: &[String],
+    ) -> impl Future<Output = Result<()>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+
+        let names = names.to_vec();
+        async move {
+            let ctr = blobstore::get_container(container.to_string())
+                .await
+                .map_err(|e| anyhow!("opening container: {e}"))?;
+            ctr.delete_objects(&names)
+                .await
+                .map_err(|e| anyhow!("deleting objects: {e}"))
+        }
+    }
+
+    /// Remove all objects from a container, leaving it empty.
+    #[cfg(target_arch = "wasm32")]
+    fn clear(&self, container: &str) -> impl Future<Output = Result<()>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+
+        async move {
+            let ctr = blobstore::get_container(container.to_string())
+                .await
+                .map_err(|e| anyhow!("opening container: {e}"))?;
+            ctr.clear().await.map_err(|e| anyhow!("clearing container: {e}"))
+        }
+    }
+
+    /// Create a new empty container.
+    #[cfg(target_arch = "wasm32")]
+    fn create_container(&self, name: &str) -> impl Future<Output = Result<()>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+
+        async move {
+            let _container = blobstore::create_container(name.to_string())
+                .await
+                .map_err(|e| anyhow!("creating container: {e}"))?;
+            Ok(())
+        }
+    }
+
+    /// Delete a container and all objects within it.
+    #[cfg(target_arch = "wasm32")]
+    fn delete_container(&self, name: &str) -> impl Future<Output = Result<()>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+
+        async move {
+            blobstore::delete_container(name.to_string())
+                .await
+                .map_err(|e| anyhow!("deleting container: {e}"))
+        }
+    }
+
+    /// Check whether a container exists.
+    #[cfg(target_arch = "wasm32")]
+    fn container_exists(&self, name: &str) -> impl Future<Output = Result<bool>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+
+        async move {
+            blobstore::container_exists(name.to_string())
+                .await
+                .map_err(|e| anyhow!("checking container existence: {e}"))
+        }
+    }
+
+    /// Return metadata for a container.
+    #[cfg(target_arch = "wasm32")]
+    fn container_info(
+        &self, container: &str,
+    ) -> impl Future<Output = Result<ContainerMetadata>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+
+        async move {
+            let ctr = blobstore::get_container(container.to_string())
+                .await
+                .map_err(|e| anyhow!("opening container: {e}"))?;
+            let info = ctr.info().map_err(|e| anyhow!("getting container info: {e}"))?;
+            Ok(ContainerMetadata {
+                name: info.name,
+                created_at: info.created_at,
+            })
+        }
+    }
+
+    /// Copy an object to the same or a different container.
+    ///
+    /// Overwrites the destination object if it already exists. Returns an
+    /// error if the destination container does not exist.
+    #[cfg(target_arch = "wasm32")]
+    fn copy_object(
+        &self, src_container: &str, src_name: &str, dest_container: &str, dest_name: &str,
+    ) -> impl Future<Output = Result<()>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+        use omnia_wasi_blobstore::types::ObjectId;
+
+        async move {
+            let src = ObjectId {
+                container: src_container.to_string(),
+                object: src_name.to_string(),
+            };
+            let dest = ObjectId {
+                container: dest_container.to_string(),
+                object: dest_name.to_string(),
+            };
+            blobstore::copy_object(&src, &dest)
+                .await
+                .map_err(|e| anyhow!("copying object: {e}"))
+        }
+    }
+
+    /// Move or rename an object to the same or a different container.
+    ///
+    /// Overwrites the destination object if it already exists. Returns an
+    /// error if the destination container does not exist.
+    #[cfg(target_arch = "wasm32")]
+    fn move_object(
+        &self, src_container: &str, src_name: &str, dest_container: &str, dest_name: &str,
+    ) -> impl Future<Output = Result<()>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+        use omnia_wasi_blobstore::types::ObjectId;
+
+        async move {
+            let src = ObjectId {
+                container: src_container.to_string(),
+                object: src_name.to_string(),
+            };
+            let dest = ObjectId {
+                container: dest_container.to_string(),
+                object: dest_name.to_string(),
+            };
+            blobstore::move_object(&src, &dest)
+                .await
+                .map_err(|e| anyhow!("moving object: {e}"))
         }
     }
 }

--- a/crates/omnia-sdk/src/lib.rs
+++ b/crates/omnia-sdk/src/lib.rs
@@ -17,8 +17,8 @@ pub use {anyhow, axum, bytes, http, http_body, tracing};
 #[cfg(target_arch = "wasm32")]
 #[doc(hidden)]
 pub use {
-    omnia_wasi_http, omnia_wasi_identity, omnia_wasi_keyvalue, omnia_wasi_messaging,
-    omnia_wasi_otel, wasip3, wit_bindgen,
+    omnia_wasi_blobstore, omnia_wasi_http, omnia_wasi_identity, omnia_wasi_keyvalue,
+    omnia_wasi_messaging, omnia_wasi_otel, wasip3, wit_bindgen,
 };
 
 pub use crate::api::*;

--- a/crates/wasi-blobstore/src/host/default_impl.rs
+++ b/crates/wasi-blobstore/src/host/default_impl.rs
@@ -236,36 +236,122 @@ impl Container for InMemContainer {
 mod tests {
     use super::*;
 
+    async fn new_ctx() -> BlobstoreDefault {
+        BlobstoreDefault::connect_with(ConnectOptions).await.expect("connect")
+    }
+
     #[tokio::test]
-    async fn container_operations() {
-        let ctx = BlobstoreDefault::connect_with(ConnectOptions).await.expect("connect");
+    async fn container_crud() {
+        let ctx = new_ctx().await;
 
-        // Test create and get container
-        let container =
-            ctx.create_container("test-container".to_string()).await.expect("create container");
+        ctx.create_container("bucket".to_string()).await.expect("create");
+        assert!(ctx.container_exists("bucket".to_string()).await.expect("exists"));
 
-        // Test write and read data
-        container.write_data("object1".to_string(), b"data1".to_vec()).await.expect("write data");
+        let retrieved = ctx.get_container("bucket".to_string()).await.expect("get");
+        assert_eq!(retrieved.name().expect("name"), "bucket");
 
-        let data = container.get_data("object1".to_string(), 0, 0).await.expect("get data");
-        assert_eq!(data, Some(b"data1".to_vec()));
+        ctx.delete_container("bucket".to_string()).await.expect("delete");
+        assert!(!ctx.container_exists("bucket".to_string()).await.expect("exists after delete"));
+    }
 
-        // Test object existence
-        assert!(container.has_object("object1".to_string()).await.expect("has object"));
-        assert!(!container.has_object("object2".to_string()).await.expect("has object"));
+    #[tokio::test]
+    async fn get_nonexistent_container() {
+        let ctx = new_ctx().await;
+        let result = ctx.get_container("no-such-container".to_string()).await;
+        assert!(result.is_err());
+    }
 
-        // Test list objects
-        container.write_data("object2".to_string(), b"data2".to_vec()).await.expect("write data");
-        let mut objects = container.list_objects().await.expect("list objects");
+    #[tokio::test]
+    async fn object_crud() {
+        let ctx = new_ctx().await;
+        let container = ctx.create_container("obj-crud".to_string()).await.expect("create");
+
+        container.write_data("k1".to_string(), b"v1".to_vec()).await.expect("write");
+        let data = container.get_data("k1".to_string(), 0, 0).await.expect("get");
+        assert_eq!(data, Some(b"v1".to_vec()));
+
+        assert!(container.has_object("k1".to_string()).await.expect("has k1"));
+        assert!(!container.has_object("k2".to_string()).await.expect("has k2"));
+
+        container.write_data("k2".to_string(), b"v2".to_vec()).await.expect("write k2");
+        let mut objects = container.list_objects().await.expect("list");
         objects.sort();
-        assert_eq!(objects, vec!["object1".to_string(), "object2".to_string()]);
+        assert_eq!(objects, vec!["k1", "k2"]);
 
-        // Test delete object
-        container.delete_object("object1".to_string()).await.expect("delete object");
-        assert!(!container.has_object("object1".to_string()).await.expect("has object"));
+        container.delete_object("k1".to_string()).await.expect("delete k1");
+        assert!(!container.has_object("k1".to_string()).await.expect("has k1 after delete"));
+    }
 
-        // Test container metadata
-        let info = container.info().expect("container info");
-        assert_eq!(info.name, "test-container");
+    #[tokio::test]
+    async fn object_info_valid() {
+        let ctx = new_ctx().await;
+        let container = ctx.create_container("info-test".to_string()).await.expect("create");
+
+        let payload = b"hello world";
+        container.write_data("doc.txt".to_string(), payload.to_vec()).await.expect("write");
+
+        let meta = container.object_info("doc.txt".to_string()).await.expect("object_info");
+        assert_eq!(meta.name, "doc.txt");
+        assert_eq!(meta.container, "info-test");
+        assert_eq!(meta.size, payload.len() as u64);
+    }
+
+    #[tokio::test]
+    async fn get_nonexistent_object() {
+        let ctx = new_ctx().await;
+        let container = ctx.create_container("miss".to_string()).await.expect("create");
+
+        let data = container.get_data("ghost".to_string(), 0, 0).await.expect("get");
+        assert_eq!(data, None);
+    }
+
+    #[tokio::test]
+    async fn object_info_nonexistent() {
+        let ctx = new_ctx().await;
+        let container = ctx.create_container("miss-info".to_string()).await.expect("create");
+
+        let result = container.object_info("ghost".to_string()).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn overwrite_object() {
+        let ctx = new_ctx().await;
+        let container = ctx.create_container("overwrite".to_string()).await.expect("create");
+
+        container.write_data("key".to_string(), b"first".to_vec()).await.expect("write 1");
+        container.write_data("key".to_string(), b"second".to_vec()).await.expect("write 2");
+
+        let data = container.get_data("key".to_string(), 0, 0).await.expect("get");
+        assert_eq!(data, Some(b"second".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn delete_nonexistent_object() {
+        let ctx = new_ctx().await;
+        let container = ctx.create_container("del-miss".to_string()).await.expect("create");
+
+        container.delete_object("nope".to_string()).await.expect("delete missing should succeed");
+    }
+
+    #[tokio::test]
+    async fn empty_container_list() {
+        let ctx = new_ctx().await;
+        let container = ctx.create_container("empty".to_string()).await.expect("create");
+
+        let objects = container.list_objects().await.expect("list");
+        assert!(objects.is_empty());
+    }
+
+    #[tokio::test]
+    async fn create_container_overwrites_existing() {
+        let ctx = new_ctx().await;
+
+        let original = ctx.create_container("reused".to_string()).await.expect("create 1");
+        original.write_data("stale".to_string(), b"old".to_vec()).await.expect("write");
+
+        let fresh = ctx.create_container("reused".to_string()).await.expect("create 2");
+        let objects = fresh.list_objects().await.expect("list");
+        assert!(objects.is_empty(), "re-created container should be empty");
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -26,7 +26,6 @@ allow = [
   "CC0-1.0",
   "CDLA-Permissive-2.0",
   "ISC",
-  "OpenSSL",
   "MIT",
   "MIT-0",
   "Unicode-3.0",
@@ -35,11 +34,6 @@ allow = [
 
 [licenses.private]
 ignore = true
-
-[[licenses.clarify]]
-expression = "MIT AND ISC AND OpenSSL"
-license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
-name = "ring"
 
 [bans]
 deny = [

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -87,7 +87,7 @@ version = "0.1.13+1.0.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.cc]]
-version = "1.2.56"
+version = "1.2.57"
 criteria = "safe-to-deploy"
 
 [[exemptions.cesu8]]
@@ -295,23 +295,27 @@ version = "2.12.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.iri-string]]
-version = "0.7.10"
+version = "0.7.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.itertools]]
 version = "0.10.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.itertools]]
-version = "0.14.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.itoa]]
-version = "1.0.17"
+version = "1.0.18"
 criteria = "safe-to-deploy"
 
 [[exemptions.jni-sys]]
-version = "0.3.0"
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.jni-sys]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.jni-sys-macros]]
+version = "0.4.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.jobserver]]
@@ -355,7 +359,7 @@ version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.moka]]
-version = "0.12.14"
+version = "0.12.15"
 criteria = "safe-to-deploy"
 
 [[exemptions.munge]]
@@ -364,6 +368,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.munge_macro]]
 version = "0.4.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.num-conv]]
+version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.oauth2]]
@@ -431,7 +439,7 @@ version = "0.2.21"
 criteria = "safe-to-deploy"
 
 [[exemptions.proptest]]
-version = "1.10.0"
+version = "1.11.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.prost]]
@@ -599,7 +607,7 @@ version = "0.8.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.tinyvec]]
-version = "1.10.0"
+version = "1.11.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-rustls]]
@@ -651,7 +659,7 @@ version = "0.32.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tracing-subscriber]]
-version = "0.3.22"
+version = "0.3.23"
 criteria = "safe-to-deploy"
 
 [[exemptions.tungstenite]]
@@ -747,11 +755,11 @@ version = "0.8.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy]]
-version = "0.8.42"
+version = "0.8.47"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy-derive]]
-version = "0.8.42"
+version = "0.8.47"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerotrie]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -16,8 +16,8 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.anstyle]]
-version = "1.0.13"
-when = "2025-09-29"
+version = "1.0.14"
+when = "2026-03-13"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
@@ -156,14 +156,14 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.cmake]]
-version = "0.1.57"
-when = "2025-12-17"
+version = "0.1.58"
+when = "2026-03-26"
 user-id = 55123
 user-login = "rust-lang-owner"
 
 [[publisher.colorchoice]]
-version = "1.0.4"
-when = "2025-06-04"
+version = "1.0.5"
+when = "2026-03-13"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
@@ -1853,6 +1853,15 @@ delta = "0.10.5 -> 0.12.1"
 notes = """
 Minimal `unsafe` usage. Few blocks that existed looked reasonable. Does what it
 says on the tin: lots of iterators.
+"""
+
+[[audits.bytecode-alliance.audits.itertools]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.12.1 -> 0.14.0"
+notes = """
+Lots of new iterators and shuffling some things around. Some new unsafe code but
+it's well-documented and well-tested. Nothing suspicious.
 """
 
 [[audits.bytecode-alliance.audits.leb128]]
@@ -3550,23 +3559,6 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.4.26 -> 0.4.29"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.num-conv]]
-who = "Alex Franchuk <afranchuk@mozilla.com>"
-criteria = "safe-to-deploy"
-version = "0.1.0"
-notes = """
-Very straightforward, simple crate. No dependencies, unsafe, extern,
-side-effectful std functions, etc.
-"""
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.num-conv]]
-who = "Lars Eggert <lars@eggert.org>"
-criteria = "safe-to-deploy"
-delta = "0.1.0 -> 0.2.0"
-notes = "Revision only removes code"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.percent-encoding]]


### PR DESCRIPTION
Blobstore capability and tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new blob storage capability surface in `omnia-sdk` and wires it to WASI bindings for `wasm32`, which could affect guest storage behavior and error handling. Also updates dependency/audit configuration, so build and supply-chain checks may change.
> 
> **Overview**
> Adds a new `BlobStore` capability to `omnia-sdk` (plus `ContainerMetadata`/`ObjectMetadata`) with `wasm32` default implementations backed by `omnia-wasi-blobstore`, and exports the blobstore bindings for guest use.
> 
> Expands the in-memory `wasi-blobstore` host default implementation test suite to cover container/object CRUD, metadata, overwrite semantics, and missing-object/container behaviors.
> 
> Updates toolchain/config files to accommodate new/transitive deps (e.g., allow duplicate `jni-sys`) and refreshes cargo-deny/cargo-vet data, including license configuration and audit/exemption entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db56ad1466e9ab1bbc35e22e6bf32c67c302aa3b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->