### PR TITLE
Blobstore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,6 +2144,7 @@ dependencies = [
  "http",
  "http-body",
  "omnia-guest-macro",
+ "omnia-wasi-blobstore",
  "omnia-wasi-config",
  "omnia-wasi-http",
  "omnia-wasi-identity",

--- a/clippy.toml
+++ b/clippy.toml
@@ -11,6 +11,7 @@ doc-valid-idents = [
 
 allowed-duplicate-crates = [
   "core-foundation",
+  "jni-sys",
   "cpufeatures",
   "embedded-io",
   "foldhash",

--- a/crates/omnia-sdk/Cargo.toml
+++ b/crates/omnia-sdk/Cargo.toml
@@ -28,6 +28,7 @@ tracing.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 omnia-guest-macro.workspace = true
+omnia-wasi-blobstore.workspace = true
 omnia-wasi-config.workspace = true
 omnia-wasi-http.workspace = true
 omnia-wasi-identity.workspace = true

--- a/crates/omnia-sdk/src/capabilities.rs
+++ b/crates/omnia-sdk/src/capabilities.rs
@@ -635,9 +635,7 @@ pub trait BlobStore: Send + Sync {
             let ctr = blobstore::get_container(container.to_string())
                 .await
                 .map_err(|e| anyhow!("opening container: {e}"))?;
-            ctr.delete_objects(&names)
-                .await
-                .map_err(|e| anyhow!("deleting objects: {e}"))
+            ctr.delete_objects(&names).await.map_err(|e| anyhow!("deleting objects: {e}"))
         }
     }
 
@@ -730,9 +728,7 @@ pub trait BlobStore: Send + Sync {
                 container: dest_container.to_string(),
                 object: dest_name.to_string(),
             };
-            blobstore::copy_object(&src, &dest)
-                .await
-                .map_err(|e| anyhow!("copying object: {e}"))
+            blobstore::copy_object(&src, &dest).await.map_err(|e| anyhow!("copying object: {e}"))
         }
     }
 
@@ -756,9 +752,7 @@ pub trait BlobStore: Send + Sync {
                 container: dest_container.to_string(),
                 object: dest_name.to_string(),
             };
-            blobstore::move_object(&src, &dest)
-                .await
-                .map_err(|e| anyhow!("moving object: {e}"))
+            blobstore::move_object(&src, &dest).await.map_err(|e| anyhow!("moving object: {e}"))
         }
     }
 }

--- a/crates/omnia-sdk/src/capabilities.rs
+++ b/crates/omnia-sdk/src/capabilities.rs
@@ -333,3 +333,143 @@ pub trait Broadcast: Send + Sync {
         }
     }
 }
+
+/// Binary large object storage (WASI Blobstore).
+///
+/// Default WASM implementations delegate to `wasi:blobstore` via
+/// `omnia-wasi-blobstore`.
+pub trait BlobStore: Send + Sync {
+    /// Retrieve an object's data from a container.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn get(
+        &self, container: &str, name: &str,
+    ) -> impl Future<Output = Result<Option<Vec<u8>>>> + Send;
+
+    /// Store an object in a container.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn put(
+        &self, container: &str, name: &str, data: &[u8],
+    ) -> impl Future<Output = Result<()>> + Send;
+
+    /// Delete an object from a container.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn delete(&self, container: &str, name: &str) -> impl Future<Output = Result<()>> + Send;
+
+    /// Check whether an object exists in a container.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn has(&self, container: &str, name: &str) -> impl Future<Output = Result<bool>> + Send;
+
+    /// List all object names in a container.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn list(&self, container: &str) -> impl Future<Output = Result<Vec<String>>> + Send;
+
+    /// Retrieve an object's data from a container.
+    #[cfg(target_arch = "wasm32")]
+    fn get(
+        &self, container: &str, name: &str,
+    ) -> impl Future<Output = Result<Option<Vec<u8>>>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+        use omnia_wasi_blobstore::types::IncomingValue;
+
+        async move {
+            let ctr = blobstore::get_container(container.to_string())
+                .await
+                .map_err(|e| anyhow!("opening container: {e}"))?;
+            if !ctr
+                .has_object(name.to_string())
+                .await
+                .map_err(|e| anyhow!("checking object existence: {e}"))?
+            {
+                return Ok(None);
+            }
+            let incoming = ctr
+                .get_data(name.to_string(), 0, u64::MAX)
+                .await
+                .map_err(|e| anyhow!("reading object: {e}"))?;
+            let data = IncomingValue::incoming_value_consume_sync(incoming)
+                .map_err(|e| anyhow!("consuming incoming value: {e}"))?;
+            Ok(Some(data))
+        }
+    }
+
+    /// Store an object in a container.
+    #[cfg(target_arch = "wasm32")]
+    fn put(
+        &self, container: &str, name: &str, data: &[u8],
+    ) -> impl Future<Output = Result<()>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+        use omnia_wasi_blobstore::types::OutgoingValue;
+
+        async move {
+            let ctr = blobstore::get_container(container.to_string())
+                .await
+                .map_err(|e| anyhow!("opening container: {e}"))?;
+            let outgoing = OutgoingValue::new_outgoing_value();
+            {
+                let body = outgoing
+                    .outgoing_value_write_body()
+                    .await
+                    .map_err(|e| anyhow!("getting write body: {e}"))?;
+                body.blocking_write_and_flush(data).map_err(|e| anyhow!("writing data: {e}"))?;
+            }
+            ctr.write_data(name.to_string(), &outgoing)
+                .await
+                .map_err(|e| anyhow!("writing object: {e}"))?;
+            OutgoingValue::finish(outgoing).map_err(|e| anyhow!("finishing write: {e}"))?;
+            Ok(())
+        }
+    }
+
+    /// Delete an object from a container.
+    #[cfg(target_arch = "wasm32")]
+    fn delete(&self, container: &str, name: &str) -> impl Future<Output = Result<()>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+
+        async move {
+            let ctr = blobstore::get_container(container.to_string())
+                .await
+                .map_err(|e| anyhow!("opening container: {e}"))?;
+            ctr.delete_object(name.to_string()).await.map_err(|e| anyhow!("deleting object: {e}"))
+        }
+    }
+
+    /// Check whether an object exists in a container.
+    #[cfg(target_arch = "wasm32")]
+    fn has(&self, container: &str, name: &str) -> impl Future<Output = Result<bool>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+
+        async move {
+            let ctr = blobstore::get_container(container.to_string())
+                .await
+                .map_err(|e| anyhow!("opening container: {e}"))?;
+            ctr.has_object(name.to_string())
+                .await
+                .map_err(|e| anyhow!("checking object existence: {e}"))
+        }
+    }
+
+    /// List all object names in a container.
+    #[cfg(target_arch = "wasm32")]
+    fn list(&self, container: &str) -> impl Future<Output = Result<Vec<String>>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+
+        async move {
+            let ctr = blobstore::get_container(container.to_string())
+                .await
+                .map_err(|e| anyhow!("opening container: {e}"))?;
+            let stream = ctr.list_objects().await.map_err(|e| anyhow!("listing objects: {e}"))?;
+            let mut names = Vec::new();
+            loop {
+                let (batch, done) = stream
+                    .read_stream_object_names(100)
+                    .await
+                    .map_err(|e| anyhow!("reading object names: {e}"))?;
+                names.extend(batch);
+                if done {
+                    break;
+                }
+            }
+            Ok(names)
+        }
+    }
+}

--- a/crates/omnia-sdk/src/capabilities.rs
+++ b/crates/omnia-sdk/src/capabilities.rs
@@ -334,11 +334,41 @@ pub trait Broadcast: Send + Sync {
     }
 }
 
+/// Metadata for a blobstore container.
+///
+/// Mirrors the `container-metadata` record from `wasi:blobstore/types`.
+#[derive(Clone, Debug)]
+pub struct ContainerMetadata {
+    /// The container's name.
+    pub name: String,
+    /// Seconds since Unix epoch when the container was created.
+    pub created_at: u64,
+}
+
+/// Metadata for an object in a blobstore container.
+///
+/// Mirrors the `object-metadata` record from `wasi:blobstore/types`.
+#[derive(Clone, Debug)]
+pub struct ObjectMetadata {
+    /// The object's name.
+    pub name: String,
+    /// The object's parent container.
+    pub container: String,
+    /// Seconds since Unix epoch when the object was created.
+    pub created_at: u64,
+    /// Size of the object in bytes.
+    pub size: u64,
+}
+
 /// Binary large object storage (WASI Blobstore).
 ///
 /// Default WASM implementations delegate to `wasi:blobstore` via
 /// `omnia-wasi-blobstore`.
 pub trait BlobStore: Send + Sync {
+    // ------------------------------------------------------------------
+    // Object operations
+    // ------------------------------------------------------------------
+
     /// Retrieve an object's data from a container.
     #[cfg(not(target_arch = "wasm32"))]
     fn get(
@@ -362,6 +392,78 @@ pub trait BlobStore: Send + Sync {
     /// List all object names in a container.
     #[cfg(not(target_arch = "wasm32"))]
     fn list(&self, container: &str) -> impl Future<Output = Result<Vec<String>>> + Send;
+
+    /// Retrieve a byte range of an object's data.
+    ///
+    /// Both `start` and `end` offsets are inclusive.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn get_range(
+        &self, container: &str, name: &str, start: u64, end: u64,
+    ) -> impl Future<Output = Result<Vec<u8>>> + Send;
+
+    /// Return metadata for an object.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn object_info(
+        &self, container: &str, name: &str,
+    ) -> impl Future<Output = Result<ObjectMetadata>> + Send;
+
+    /// Delete multiple objects from a container.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn delete_objects(
+        &self, container: &str, names: &[String],
+    ) -> impl Future<Output = Result<()>> + Send;
+
+    /// Remove all objects from a container, leaving it empty.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn clear(&self, container: &str) -> impl Future<Output = Result<()>> + Send;
+
+    // ------------------------------------------------------------------
+    // Container management
+    // ------------------------------------------------------------------
+
+    /// Create a new empty container.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn create_container(&self, name: &str) -> impl Future<Output = Result<()>> + Send;
+
+    /// Delete a container and all objects within it.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn delete_container(&self, name: &str) -> impl Future<Output = Result<()>> + Send;
+
+    /// Check whether a container exists.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn container_exists(&self, name: &str) -> impl Future<Output = Result<bool>> + Send;
+
+    /// Return metadata for a container.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn container_info(
+        &self, container: &str,
+    ) -> impl Future<Output = Result<ContainerMetadata>> + Send;
+
+    // ------------------------------------------------------------------
+    // Cross-container operations
+    // ------------------------------------------------------------------
+
+    /// Copy an object to the same or a different container.
+    ///
+    /// Overwrites the destination object if it already exists. Returns an
+    /// error if the destination container does not exist.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn copy_object(
+        &self, src_container: &str, src_name: &str, dest_container: &str, dest_name: &str,
+    ) -> impl Future<Output = Result<()>> + Send;
+
+    /// Move or rename an object to the same or a different container.
+    ///
+    /// Overwrites the destination object if it already exists. Returns an
+    /// error if the destination container does not exist.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn move_object(
+        &self, src_container: &str, src_name: &str, dest_container: &str, dest_name: &str,
+    ) -> impl Future<Output = Result<()>> + Send;
+
+    // ------------------------------------------------------------------
+    // WASM default implementations
+    // ------------------------------------------------------------------
 
     /// Retrieve an object's data from a container.
     #[cfg(target_arch = "wasm32")]
@@ -470,6 +572,193 @@ pub trait BlobStore: Send + Sync {
                 }
             }
             Ok(names)
+        }
+    }
+
+    /// Retrieve a byte range of an object's data.
+    ///
+    /// Both `start` and `end` offsets are inclusive.
+    #[cfg(target_arch = "wasm32")]
+    fn get_range(
+        &self, container: &str, name: &str, start: u64, end: u64,
+    ) -> impl Future<Output = Result<Vec<u8>>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+        use omnia_wasi_blobstore::types::IncomingValue;
+
+        async move {
+            let ctr = blobstore::get_container(container.to_string())
+                .await
+                .map_err(|e| anyhow!("opening container: {e}"))?;
+            let incoming = ctr
+                .get_data(name.to_string(), start, end)
+                .await
+                .map_err(|e| anyhow!("reading object range: {e}"))?;
+            let data = IncomingValue::incoming_value_consume_sync(incoming)
+                .map_err(|e| anyhow!("consuming incoming value: {e}"))?;
+            Ok(data)
+        }
+    }
+
+    /// Return metadata for an object.
+    #[cfg(target_arch = "wasm32")]
+    fn object_info(
+        &self, container: &str, name: &str,
+    ) -> impl Future<Output = Result<ObjectMetadata>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+
+        async move {
+            let ctr = blobstore::get_container(container.to_string())
+                .await
+                .map_err(|e| anyhow!("opening container: {e}"))?;
+            let info = ctr
+                .object_info(name.to_string())
+                .await
+                .map_err(|e| anyhow!("getting object info: {e}"))?;
+            Ok(ObjectMetadata {
+                name: info.name,
+                container: info.container,
+                created_at: info.created_at,
+                size: info.size,
+            })
+        }
+    }
+
+    /// Delete multiple objects from a container.
+    #[cfg(target_arch = "wasm32")]
+    fn delete_objects(
+        &self, container: &str, names: &[String],
+    ) -> impl Future<Output = Result<()>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+
+        let names = names.to_vec();
+        async move {
+            let ctr = blobstore::get_container(container.to_string())
+                .await
+                .map_err(|e| anyhow!("opening container: {e}"))?;
+            ctr.delete_objects(&names)
+                .await
+                .map_err(|e| anyhow!("deleting objects: {e}"))
+        }
+    }
+
+    /// Remove all objects from a container, leaving it empty.
+    #[cfg(target_arch = "wasm32")]
+    fn clear(&self, container: &str) -> impl Future<Output = Result<()>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+
+        async move {
+            let ctr = blobstore::get_container(container.to_string())
+                .await
+                .map_err(|e| anyhow!("opening container: {e}"))?;
+            ctr.clear().await.map_err(|e| anyhow!("clearing container: {e}"))
+        }
+    }
+
+    /// Create a new empty container.
+    #[cfg(target_arch = "wasm32")]
+    fn create_container(&self, name: &str) -> impl Future<Output = Result<()>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+
+        async move {
+            let _container = blobstore::create_container(name.to_string())
+                .await
+                .map_err(|e| anyhow!("creating container: {e}"))?;
+            Ok(())
+        }
+    }
+
+    /// Delete a container and all objects within it.
+    #[cfg(target_arch = "wasm32")]
+    fn delete_container(&self, name: &str) -> impl Future<Output = Result<()>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+
+        async move {
+            blobstore::delete_container(name.to_string())
+                .await
+                .map_err(|e| anyhow!("deleting container: {e}"))
+        }
+    }
+
+    /// Check whether a container exists.
+    #[cfg(target_arch = "wasm32")]
+    fn container_exists(&self, name: &str) -> impl Future<Output = Result<bool>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+
+        async move {
+            blobstore::container_exists(name.to_string())
+                .await
+                .map_err(|e| anyhow!("checking container existence: {e}"))
+        }
+    }
+
+    /// Return metadata for a container.
+    #[cfg(target_arch = "wasm32")]
+    fn container_info(
+        &self, container: &str,
+    ) -> impl Future<Output = Result<ContainerMetadata>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+
+        async move {
+            let ctr = blobstore::get_container(container.to_string())
+                .await
+                .map_err(|e| anyhow!("opening container: {e}"))?;
+            let info = ctr.info().map_err(|e| anyhow!("getting container info: {e}"))?;
+            Ok(ContainerMetadata {
+                name: info.name,
+                created_at: info.created_at,
+            })
+        }
+    }
+
+    /// Copy an object to the same or a different container.
+    ///
+    /// Overwrites the destination object if it already exists. Returns an
+    /// error if the destination container does not exist.
+    #[cfg(target_arch = "wasm32")]
+    fn copy_object(
+        &self, src_container: &str, src_name: &str, dest_container: &str, dest_name: &str,
+    ) -> impl Future<Output = Result<()>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+        use omnia_wasi_blobstore::types::ObjectId;
+
+        async move {
+            let src = ObjectId {
+                container: src_container.to_string(),
+                object: src_name.to_string(),
+            };
+            let dest = ObjectId {
+                container: dest_container.to_string(),
+                object: dest_name.to_string(),
+            };
+            blobstore::copy_object(&src, &dest)
+                .await
+                .map_err(|e| anyhow!("copying object: {e}"))
+        }
+    }
+
+    /// Move or rename an object to the same or a different container.
+    ///
+    /// Overwrites the destination object if it already exists. Returns an
+    /// error if the destination container does not exist.
+    #[cfg(target_arch = "wasm32")]
+    fn move_object(
+        &self, src_container: &str, src_name: &str, dest_container: &str, dest_name: &str,
+    ) -> impl Future<Output = Result<()>> + Send {
+        use omnia_wasi_blobstore::blobstore;
+        use omnia_wasi_blobstore::types::ObjectId;
+
+        async move {
+            let src = ObjectId {
+                container: src_container.to_string(),
+                object: src_name.to_string(),
+            };
+            let dest = ObjectId {
+                container: dest_container.to_string(),
+                object: dest_name.to_string(),
+            };
+            blobstore::move_object(&src, &dest)
+                .await
+                .map_err(|e| anyhow!("moving object: {e}"))
         }
     }
 }

--- a/crates/omnia-sdk/src/lib.rs
+++ b/crates/omnia-sdk/src/lib.rs
@@ -17,8 +17,8 @@ pub use {anyhow, axum, bytes, http, http_body, tracing};
 #[cfg(target_arch = "wasm32")]
 #[doc(hidden)]
 pub use {
-    omnia_wasi_http, omnia_wasi_identity, omnia_wasi_keyvalue, omnia_wasi_messaging,
-    omnia_wasi_otel, wasip3, wit_bindgen,
+    omnia_wasi_blobstore, omnia_wasi_http, omnia_wasi_identity, omnia_wasi_keyvalue,
+    omnia_wasi_messaging, omnia_wasi_otel, wasip3, wit_bindgen,
 };
 
 pub use crate::api::*;

--- a/crates/wasi-blobstore/src/host.rs
+++ b/crates/wasi-blobstore/src/host.rs
@@ -50,7 +50,43 @@ use self::generated::wasi::blobstore::{blobstore, container, types};
 /// Incoming value for a blobstore operation.
 pub type IncomingValue = Bytes;
 /// Outgoing value for a blobstore operation.
-pub type OutgoingValue = MemoryOutputPipe;
+#[derive(Debug, Clone)]
+pub struct OutgoingValue {
+    pub(crate) pipe: MemoryOutputPipe,
+    pub(crate) write_body_taken: bool,
+    pub(crate) finished: bool,
+}
+
+impl OutgoingValue {
+    /// Create a new outgoing value with an in-memory buffer capacity.
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            pipe: MemoryOutputPipe::new(capacity),
+            write_body_taken: false,
+            finished: false,
+        }
+    }
+
+    pub(crate) fn take_write_body(&mut self) -> std::result::Result<(), ()> {
+        if self.finished || self.write_body_taken {
+            return Err(());
+        }
+        self.write_body_taken = true;
+        Ok(())
+    }
+
+    pub(crate) fn finalize(&mut self) -> std::result::Result<(), &'static str> {
+        if self.finished {
+            return Err("outgoing value already finished");
+        }
+        if !self.write_body_taken {
+            return Err("outgoing value write body was never requested");
+        }
+        self.finished = true;
+        Ok(())
+    }
+}
 /// Stream of object names with position tracking for paginated reads.
 pub struct StreamObjectNames {
     /// The full list of object names in this stream.
@@ -161,3 +197,29 @@ macro_rules! omnia_wasi_view {
 //         }
 //     };
 // }
+
+#[cfg(test)]
+mod tests {
+    use super::OutgoingValue;
+
+    #[test]
+    fn outgoing_value_write_body_is_one_shot() {
+        let mut outgoing = OutgoingValue::new(16);
+        assert_eq!(outgoing.take_write_body(), Ok(()));
+        assert_eq!(outgoing.take_write_body(), Err(()));
+    }
+
+    #[test]
+    fn outgoing_value_finish_requires_write_body() {
+        let mut outgoing = OutgoingValue::new(16);
+        assert_eq!(outgoing.finalize(), Err("outgoing value write body was never requested"));
+    }
+
+    #[test]
+    fn outgoing_value_finish_is_single_use() {
+        let mut outgoing = OutgoingValue::new(16);
+        assert_eq!(outgoing.take_write_body(), Ok(()));
+        assert_eq!(outgoing.finalize(), Ok(()));
+        assert_eq!(outgoing.finalize(), Err("outgoing value already finished"));
+    }
+}

--- a/crates/wasi-blobstore/src/host.rs
+++ b/crates/wasi-blobstore/src/host.rs
@@ -51,8 +51,21 @@ use self::generated::wasi::blobstore::{blobstore, container, types};
 pub type IncomingValue = Bytes;
 /// Outgoing value for a blobstore operation.
 pub type OutgoingValue = MemoryOutputPipe;
-/// Stream of object names.
-pub type StreamObjectNames = Vec<String>;
+/// Stream of object names with position tracking for paginated reads.
+pub struct StreamObjectNames {
+    /// The full list of object names in this stream.
+    pub(crate) names: Vec<String>,
+    /// Current read offset into `names`.
+    pub(crate) offset: usize,
+}
+
+impl StreamObjectNames {
+    /// Create a new stream from a complete list of object names.
+    #[must_use]
+    pub const fn new(names: Vec<String>) -> Self {
+        Self { names, offset: 0 }
+    }
+}
 
 /// Result type for blobstore operations.
 pub type Result<T> = anyhow::Result<T, Error>;

--- a/crates/wasi-blobstore/src/host.rs
+++ b/crates/wasi-blobstore/src/host.rs
@@ -68,7 +68,7 @@ impl OutgoingValue {
         }
     }
 
-    pub(crate) fn take_write_body(&mut self) -> std::result::Result<(), ()> {
+    pub(crate) const fn take_write_body(&mut self) -> std::result::Result<(), ()> {
         if self.finished || self.write_body_taken {
             return Err(());
         }
@@ -76,7 +76,7 @@ impl OutgoingValue {
         Ok(())
     }
 
-    pub(crate) fn finalize(&mut self) -> std::result::Result<(), &'static str> {
+    pub(crate) const fn finalize(&mut self) -> std::result::Result<(), &'static str> {
         if self.finished {
             return Err("outgoing value already finished");
         }

--- a/crates/wasi-blobstore/src/host/blobstore_impl.rs
+++ b/crates/wasi-blobstore/src/host/blobstore_impl.rs
@@ -4,6 +4,10 @@ use crate::host::generated::wasi::blobstore::blobstore::{Host, HostWithStore, Ob
 use crate::host::resource::ContainerProxy;
 use crate::host::{Result, WasiBlobstore, WasiBlobstoreCtxView};
 
+fn same_object(src: &ObjectId, dest: &ObjectId) -> bool {
+    src.container == dest.container && src.object == dest.object
+}
+
 impl HostWithStore for WasiBlobstore {
     async fn create_container<T>(
         accessor: &Accessor<T, Self>, name: String,
@@ -86,6 +90,11 @@ impl HostWithStore for WasiBlobstore {
             dest.object
         );
 
+        if same_object(&src, &dest) {
+            // No-op for identical source and destination; deleting would corrupt data.
+            return Ok(());
+        }
+
         let src_container = accessor
             .with(|mut store| store.get().ctx.get_container(src.container.clone()))
             .await
@@ -110,3 +119,34 @@ impl HostWithStore for WasiBlobstore {
 }
 
 impl Host for WasiBlobstoreCtxView<'_> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_object_detects_identical_ids() {
+        let a = ObjectId {
+            container: "bucket".to_string(),
+            object: "blob".to_string(),
+        };
+        let b = ObjectId {
+            container: "bucket".to_string(),
+            object: "blob".to_string(),
+        };
+        assert!(same_object(&a, &b));
+    }
+
+    #[test]
+    fn same_object_rejects_different_ids() {
+        let a = ObjectId {
+            container: "bucket".to_string(),
+            object: "blob".to_string(),
+        };
+        let b = ObjectId {
+            container: "bucket".to_string(),
+            object: "blob-2".to_string(),
+        };
+        assert!(!same_object(&a, &b));
+    }
+}

--- a/crates/wasi-blobstore/src/host/blobstore_impl.rs
+++ b/crates/wasi-blobstore/src/host/blobstore_impl.rs
@@ -45,12 +45,67 @@ impl HostWithStore for WasiBlobstore {
             .map_err(|e| e.to_string())
     }
 
-    async fn copy_object<T>(_: &Accessor<T, Self>, _src: ObjectId, _dest: ObjectId) -> Result<()> {
-        unimplemented!("copy_object not implemented yet")
+    async fn copy_object<T>(
+        accessor: &Accessor<T, Self>, src: ObjectId, dest: ObjectId,
+    ) -> Result<()> {
+        tracing::trace!(
+            "copy_object: {}/{} -> {}/{}",
+            src.container,
+            src.object,
+            dest.container,
+            dest.object
+        );
+
+        let src_container = accessor
+            .with(|mut store| store.get().ctx.get_container(src.container.clone()))
+            .await
+            .map_err(|e| e.to_string())?;
+
+        let data = src_container
+            .get_data(src.object.clone(), 0, u64::MAX)
+            .await
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| format!("source object not found: {}/{}", src.container, src.object))?;
+
+        let dest_container = accessor
+            .with(|mut store| store.get().ctx.get_container(dest.container.clone()))
+            .await
+            .map_err(|e| e.to_string())?;
+
+        dest_container.write_data(dest.object, data).await.map_err(|e| e.to_string())
     }
 
-    async fn move_object<T>(_: &Accessor<T, Self>, _src: ObjectId, _dest: ObjectId) -> Result<()> {
-        unimplemented!("move_object not implemented yet")
+    async fn move_object<T>(
+        accessor: &Accessor<T, Self>, src: ObjectId, dest: ObjectId,
+    ) -> Result<()> {
+        tracing::trace!(
+            "move_object: {}/{} -> {}/{}",
+            src.container,
+            src.object,
+            dest.container,
+            dest.object
+        );
+
+        let src_container = accessor
+            .with(|mut store| store.get().ctx.get_container(src.container.clone()))
+            .await
+            .map_err(|e| e.to_string())?;
+
+        let src_object_name = src.object.clone();
+        let data = src_container
+            .get_data(src.object.clone(), 0, u64::MAX)
+            .await
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| format!("source object not found: {}/{}", src.container, src.object))?;
+
+        let dest_container = accessor
+            .with(|mut store| store.get().ctx.get_container(dest.container.clone()))
+            .await
+            .map_err(|e| e.to_string())?;
+
+        dest_container.write_data(dest.object, data).await.map_err(|e| e.to_string())?;
+
+        src_container.delete_object(src_object_name).await.map_err(|e| e.to_string())
     }
 }
 

--- a/crates/wasi-blobstore/src/host/container_impl.rs
+++ b/crates/wasi-blobstore/src/host/container_impl.rs
@@ -1,17 +1,15 @@
 use anyhow::Context;
 use bytes::{Bytes, BytesMut};
 use wasmtime::component::{Access, Accessor, Resource};
-use wasmtime_wasi::p2::pipe::MemoryOutputPipe;
 
 use crate::host::generated::wasi::blobstore::container::{
     ContainerMetadata, Host, HostContainer, HostContainerWithStore, HostStreamObjectNames,
     HostStreamObjectNamesWithStore, ObjectMetadata,
 };
 use crate::host::resource::ContainerProxy;
-use crate::host::{Result, StreamObjectNames, WasiBlobstore, WasiBlobstoreCtxView};
+use crate::host::{OutgoingValue, Result, StreamObjectNames, WasiBlobstore, WasiBlobstoreCtxView};
 
 pub type IncomingValue = Bytes;
-pub type OutgoingValue = MemoryOutputPipe;
 
 impl HostContainerWithStore for WasiBlobstore {
     fn name<T>(mut host: Access<'_, T, Self>, self_: Resource<ContainerProxy>) -> Result<String> {
@@ -65,7 +63,7 @@ impl HostContainerWithStore for WasiBlobstore {
         let bytes = accessor
             .with(|mut store| {
                 let value = store.get().table.get(&data)?;
-                Ok::<Vec<u8>, wasmtime::Error>(value.contents().to_vec())
+                Ok::<Vec<u8>, wasmtime::Error>(value.pipe.contents().to_vec())
             })
             .map_err(|e| e.to_string())?;
 

--- a/crates/wasi-blobstore/src/host/container_impl.rs
+++ b/crates/wasi-blobstore/src/host/container_impl.rs
@@ -8,11 +8,10 @@ use crate::host::generated::wasi::blobstore::container::{
     HostStreamObjectNamesWithStore, ObjectMetadata,
 };
 use crate::host::resource::ContainerProxy;
-use crate::host::{Result, WasiBlobstore, WasiBlobstoreCtxView};
+use crate::host::{Result, StreamObjectNames, WasiBlobstore, WasiBlobstoreCtxView};
 
 pub type IncomingValue = Bytes;
 pub type OutgoingValue = MemoryOutputPipe;
-pub type StreamObjectNames = Vec<String>;
 
 impl HostContainerWithStore for WasiBlobstore {
     fn name<T>(mut host: Access<'_, T, Self>, self_: Resource<ContainerProxy>) -> Result<String> {
@@ -86,7 +85,8 @@ impl HostContainerWithStore for WasiBlobstore {
         let container = get_container(accessor, &self_)?;
         let names =
             container.list_objects().await.context("listing objects").map_err(|e| e.to_string())?;
-        accessor.with(|mut store| store.get().table.push(names)).map_err(|e| e.to_string())
+        let stream = StreamObjectNames::new(names);
+        accessor.with(|mut store| store.get().table.push(stream)).map_err(|e| e.to_string())
     }
 
     async fn delete_object<T>(
@@ -155,15 +155,42 @@ impl HostContainerWithStore for WasiBlobstore {
 
 impl HostStreamObjectNamesWithStore for WasiBlobstore {
     async fn read_stream_object_names<T>(
-        _: &Accessor<T, Self>, _self_: Resource<StreamObjectNames>, _len: u64,
+        accessor: &Accessor<T, Self>, self_: Resource<StreamObjectNames>, len: u64,
     ) -> Result<(Vec<String>, bool)> {
-        Err("stream object names not yet supported".to_string())
+        accessor.with(|mut store| {
+            let stream = store
+                .get()
+                .table
+                .get_mut(&self_)
+                .context("StreamObjectNames not found")
+                .map_err(|e| e.to_string())?;
+
+            let remaining = &stream.names[stream.offset..];
+            let take = usize::try_from(len).unwrap_or(usize::MAX).min(remaining.len());
+            let batch = remaining[..take].to_vec();
+            stream.offset += take;
+            let done = stream.offset >= stream.names.len();
+            Ok((batch, done))
+        })
     }
 
     async fn skip_stream_object_names<T>(
-        _: &Accessor<T, Self>, _names_ref: Resource<StreamObjectNames>, _num: u64,
+        accessor: &Accessor<T, Self>, self_: Resource<StreamObjectNames>, num: u64,
     ) -> Result<(u64, bool)> {
-        Err("stream object names not yet supported".to_string())
+        accessor.with(|mut store| {
+            let stream = store
+                .get()
+                .table
+                .get_mut(&self_)
+                .context("StreamObjectNames not found")
+                .map_err(|e| e.to_string())?;
+
+            let remaining = stream.names.len() - stream.offset;
+            let skip = usize::try_from(num).unwrap_or(usize::MAX).min(remaining);
+            stream.offset += skip;
+            let done = stream.offset >= stream.names.len();
+            Ok((skip as u64, done))
+        })
     }
 
     fn drop<T>(

--- a/crates/wasi-blobstore/src/host/default_impl.rs
+++ b/crates/wasi-blobstore/src/host/default_impl.rs
@@ -235,6 +235,7 @@ impl Container for InMemContainer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::host::StreamObjectNames;
 
     async fn new_ctx() -> BlobstoreDefault {
         BlobstoreDefault::connect_with(ConnectOptions).await.expect("connect")
@@ -353,5 +354,147 @@ mod tests {
         let fresh = ctx.create_container("reused".to_string()).await.expect("create 2");
         let objects = fresh.list_objects().await.expect("list");
         assert!(objects.is_empty(), "re-created container should be empty");
+    }
+
+    #[tokio::test]
+    async fn copy_object_across_containers() {
+        let ctx = new_ctx().await;
+        let src = ctx.create_container("src-bucket".to_string()).await.expect("create src");
+        let dest = ctx.create_container("dest-bucket".to_string()).await.expect("create dest");
+
+        src.write_data("file.txt".to_string(), b"payload".to_vec()).await.expect("write");
+
+        let data = src.get_data("file.txt".to_string(), 0, u64::MAX).await.expect("read src");
+        assert!(data.is_some());
+        dest.write_data("file-copy.txt".to_string(), data.unwrap()).await.expect("write dest");
+
+        let copied =
+            dest.get_data("file-copy.txt".to_string(), 0, u64::MAX).await.expect("read dest");
+        assert_eq!(copied, Some(b"payload".to_vec()));
+
+        assert!(src.has_object("file.txt".to_string()).await.expect("src still has object"));
+    }
+
+    #[tokio::test]
+    async fn copy_object_within_same_container() {
+        let ctx = new_ctx().await;
+        let ctr = ctx.create_container("same-bucket".to_string()).await.expect("create");
+
+        ctr.write_data("original".to_string(), b"data".to_vec()).await.expect("write");
+
+        let data = ctr.get_data("original".to_string(), 0, u64::MAX).await.expect("read");
+        ctr.write_data("duplicate".to_string(), data.unwrap()).await.expect("write copy");
+
+        let copied = ctr.get_data("duplicate".to_string(), 0, u64::MAX).await.expect("read copy");
+        assert_eq!(copied, Some(b"data".to_vec()));
+        assert!(ctr.has_object("original".to_string()).await.expect("original still exists"));
+    }
+
+    #[tokio::test]
+    async fn move_object_across_containers() {
+        let ctx = new_ctx().await;
+        let src = ctx.create_container("move-src".to_string()).await.expect("create src");
+        let dest = ctx.create_container("move-dest".to_string()).await.expect("create dest");
+
+        src.write_data("doc.bin".to_string(), b"binary-data".to_vec()).await.expect("write");
+
+        let data = src.get_data("doc.bin".to_string(), 0, u64::MAX).await.expect("read");
+        dest.write_data("doc-moved.bin".to_string(), data.unwrap()).await.expect("write dest");
+        src.delete_object("doc.bin".to_string()).await.expect("delete src");
+
+        let moved =
+            dest.get_data("doc-moved.bin".to_string(), 0, u64::MAX).await.expect("read dest");
+        assert_eq!(moved, Some(b"binary-data".to_vec()));
+        assert!(!src.has_object("doc.bin".to_string()).await.expect("src deleted"));
+    }
+
+    #[tokio::test]
+    async fn move_object_within_same_container() {
+        let ctx = new_ctx().await;
+        let ctr = ctx.create_container("rename-bucket".to_string()).await.expect("create");
+
+        ctr.write_data("old-name".to_string(), b"content".to_vec()).await.expect("write");
+
+        let data = ctr.get_data("old-name".to_string(), 0, u64::MAX).await.expect("read");
+        ctr.write_data("new-name".to_string(), data.unwrap()).await.expect("write renamed");
+        ctr.delete_object("old-name".to_string()).await.expect("delete old");
+
+        assert_eq!(
+            ctr.get_data("new-name".to_string(), 0, u64::MAX).await.expect("read new"),
+            Some(b"content".to_vec())
+        );
+        assert!(!ctr.has_object("old-name".to_string()).await.expect("old gone"));
+    }
+
+    #[test]
+    fn stream_object_names_read_all_at_once() {
+        let mut stream = StreamObjectNames::new(vec!["a".into(), "b".into(), "c".into()]);
+
+        let remaining = &stream.names[stream.offset..];
+        let take = 100_usize.min(remaining.len());
+        let batch: Vec<String> = remaining[..take].to_vec();
+        stream.offset += take;
+        let done = stream.offset >= stream.names.len();
+
+        assert_eq!(batch, vec!["a", "b", "c"]);
+        assert!(done);
+    }
+
+    #[test]
+    fn stream_object_names_paginated() {
+        let mut stream = StreamObjectNames::new(vec![
+            "a".into(),
+            "b".into(),
+            "c".into(),
+            "d".into(),
+            "e".into(),
+        ]);
+
+        let mut all = Vec::new();
+        let page_size = 2_usize;
+        loop {
+            let remaining = &stream.names[stream.offset..];
+            let take = page_size.min(remaining.len());
+            let batch: Vec<String> = remaining[..take].to_vec();
+            stream.offset += take;
+            let done = stream.offset >= stream.names.len();
+            all.extend(batch);
+            if done {
+                break;
+            }
+        }
+
+        assert_eq!(all, vec!["a", "b", "c", "d", "e"]);
+    }
+
+    #[test]
+    fn stream_object_names_empty() {
+        let stream = StreamObjectNames::new(vec![]);
+
+        let remaining = &stream.names[stream.offset..];
+        let take = 100_usize.min(remaining.len());
+        let batch: Vec<String> = remaining[..take].to_vec();
+        let done = stream.offset + take >= stream.names.len();
+
+        assert!(batch.is_empty());
+        assert!(done);
+    }
+
+    #[test]
+    fn stream_object_names_skip() {
+        let mut stream =
+            StreamObjectNames::new(vec!["a".into(), "b".into(), "c".into(), "d".into()]);
+
+        let remaining = stream.names.len() - stream.offset;
+        let skip = 2_usize.min(remaining);
+        stream.offset += skip;
+
+        assert_eq!(skip, 2);
+        assert_eq!(&stream.names[stream.offset..], &["c", "d"]);
+
+        let remaining2 = &stream.names[stream.offset..];
+        let take = 100_usize.min(remaining2.len());
+        let batch: Vec<String> = remaining2[..take].to_vec();
+        assert_eq!(batch, vec!["c", "d"]);
     }
 }

--- a/crates/wasi-blobstore/src/host/default_impl.rs
+++ b/crates/wasi-blobstore/src/host/default_impl.rs
@@ -236,36 +236,122 @@ impl Container for InMemContainer {
 mod tests {
     use super::*;
 
+    async fn new_ctx() -> BlobstoreDefault {
+        BlobstoreDefault::connect_with(ConnectOptions).await.expect("connect")
+    }
+
     #[tokio::test]
-    async fn container_operations() {
-        let ctx = BlobstoreDefault::connect_with(ConnectOptions).await.expect("connect");
+    async fn container_crud() {
+        let ctx = new_ctx().await;
 
-        // Test create and get container
-        let container =
-            ctx.create_container("test-container".to_string()).await.expect("create container");
+        ctx.create_container("bucket".to_string()).await.expect("create");
+        assert!(ctx.container_exists("bucket".to_string()).await.expect("exists"));
 
-        // Test write and read data
-        container.write_data("object1".to_string(), b"data1".to_vec()).await.expect("write data");
+        let retrieved = ctx.get_container("bucket".to_string()).await.expect("get");
+        assert_eq!(retrieved.name().expect("name"), "bucket");
 
-        let data = container.get_data("object1".to_string(), 0, 0).await.expect("get data");
-        assert_eq!(data, Some(b"data1".to_vec()));
+        ctx.delete_container("bucket".to_string()).await.expect("delete");
+        assert!(!ctx.container_exists("bucket".to_string()).await.expect("exists after delete"));
+    }
 
-        // Test object existence
-        assert!(container.has_object("object1".to_string()).await.expect("has object"));
-        assert!(!container.has_object("object2".to_string()).await.expect("has object"));
+    #[tokio::test]
+    async fn get_nonexistent_container() {
+        let ctx = new_ctx().await;
+        let result = ctx.get_container("no-such-container".to_string()).await;
+        assert!(result.is_err());
+    }
 
-        // Test list objects
-        container.write_data("object2".to_string(), b"data2".to_vec()).await.expect("write data");
-        let mut objects = container.list_objects().await.expect("list objects");
+    #[tokio::test]
+    async fn object_crud() {
+        let ctx = new_ctx().await;
+        let container = ctx.create_container("obj-crud".to_string()).await.expect("create");
+
+        container.write_data("k1".to_string(), b"v1".to_vec()).await.expect("write");
+        let data = container.get_data("k1".to_string(), 0, 0).await.expect("get");
+        assert_eq!(data, Some(b"v1".to_vec()));
+
+        assert!(container.has_object("k1".to_string()).await.expect("has k1"));
+        assert!(!container.has_object("k2".to_string()).await.expect("has k2"));
+
+        container.write_data("k2".to_string(), b"v2".to_vec()).await.expect("write k2");
+        let mut objects = container.list_objects().await.expect("list");
         objects.sort();
-        assert_eq!(objects, vec!["object1".to_string(), "object2".to_string()]);
+        assert_eq!(objects, vec!["k1", "k2"]);
 
-        // Test delete object
-        container.delete_object("object1".to_string()).await.expect("delete object");
-        assert!(!container.has_object("object1".to_string()).await.expect("has object"));
+        container.delete_object("k1".to_string()).await.expect("delete k1");
+        assert!(!container.has_object("k1".to_string()).await.expect("has k1 after delete"));
+    }
 
-        // Test container metadata
-        let info = container.info().expect("container info");
-        assert_eq!(info.name, "test-container");
+    #[tokio::test]
+    async fn object_info_valid() {
+        let ctx = new_ctx().await;
+        let container = ctx.create_container("info-test".to_string()).await.expect("create");
+
+        let payload = b"hello world";
+        container.write_data("doc.txt".to_string(), payload.to_vec()).await.expect("write");
+
+        let meta = container.object_info("doc.txt".to_string()).await.expect("object_info");
+        assert_eq!(meta.name, "doc.txt");
+        assert_eq!(meta.container, "info-test");
+        assert_eq!(meta.size, payload.len() as u64);
+    }
+
+    #[tokio::test]
+    async fn get_nonexistent_object() {
+        let ctx = new_ctx().await;
+        let container = ctx.create_container("miss".to_string()).await.expect("create");
+
+        let data = container.get_data("ghost".to_string(), 0, 0).await.expect("get");
+        assert_eq!(data, None);
+    }
+
+    #[tokio::test]
+    async fn object_info_nonexistent() {
+        let ctx = new_ctx().await;
+        let container = ctx.create_container("miss-info".to_string()).await.expect("create");
+
+        let result = container.object_info("ghost".to_string()).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn overwrite_object() {
+        let ctx = new_ctx().await;
+        let container = ctx.create_container("overwrite".to_string()).await.expect("create");
+
+        container.write_data("key".to_string(), b"first".to_vec()).await.expect("write 1");
+        container.write_data("key".to_string(), b"second".to_vec()).await.expect("write 2");
+
+        let data = container.get_data("key".to_string(), 0, 0).await.expect("get");
+        assert_eq!(data, Some(b"second".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn delete_nonexistent_object() {
+        let ctx = new_ctx().await;
+        let container = ctx.create_container("del-miss".to_string()).await.expect("create");
+
+        container.delete_object("nope".to_string()).await.expect("delete missing should succeed");
+    }
+
+    #[tokio::test]
+    async fn empty_container_list() {
+        let ctx = new_ctx().await;
+        let container = ctx.create_container("empty".to_string()).await.expect("create");
+
+        let objects = container.list_objects().await.expect("list");
+        assert!(objects.is_empty());
+    }
+
+    #[tokio::test]
+    async fn create_container_overwrites_existing() {
+        let ctx = new_ctx().await;
+
+        let original = ctx.create_container("reused".to_string()).await.expect("create 1");
+        original.write_data("stale".to_string(), b"old".to_vec()).await.expect("write");
+
+        let fresh = ctx.create_container("reused".to_string()).await.expect("create 2");
+        let objects = fresh.list_objects().await.expect("list");
+        assert!(objects.is_empty(), "re-created container should be empty");
     }
 }

--- a/crates/wasi-blobstore/src/host/types_impl.rs
+++ b/crates/wasi-blobstore/src/host/types_impl.rs
@@ -68,7 +68,8 @@ impl HostOutgoingValueWithStore for WasiBlobstore {
     ) -> wasmtime::Result<wasmtime::Result<wasmtime::component::Resource<OutputStream>, ()>> {
         accessor.with(|mut store| {
             let pipe = {
-                let outgoing = store.get().table.get_mut(&self_).context("OutgoingValue not found")?;
+                let outgoing =
+                    store.get().table.get_mut(&self_).context("OutgoingValue not found")?;
                 if outgoing.take_write_body().is_err() {
                     return Ok(Err(()));
                 }
@@ -81,11 +82,11 @@ impl HostOutgoingValueWithStore for WasiBlobstore {
         })
     }
 
-    fn finish<T>(mut host: Access<'_, T, Self>, self_: Resource<OutgoingValue>) -> Result<()> {
+    fn finish<T>(mut host: Access<'_, T, Self>, this: Resource<OutgoingValue>) -> Result<()> {
         let outgoing = host
             .get()
             .table
-            .get_mut(&self_)
+            .get_mut(&this)
             .context("OutgoingValue not found")
             .map_err(|e| e.to_string())?;
 

--- a/crates/wasi-blobstore/src/host/types_impl.rs
+++ b/crates/wasi-blobstore/src/host/types_impl.rs
@@ -2,17 +2,16 @@ use bytes::Bytes;
 use wasmtime::component::{Access, Accessor, Resource};
 use wasmtime::error::Context;
 use wasmtime_wasi::p2::bindings::io::streams::{InputStream, OutputStream};
-use wasmtime_wasi::p2::pipe::{MemoryInputPipe, MemoryOutputPipe};
+use wasmtime_wasi::p2::pipe::MemoryInputPipe;
 
 use crate::host::generated::Error;
 use crate::host::generated::wasi::blobstore::types::{
     Host, HostIncomingValue, HostIncomingValueWithStore, HostOutgoingValue,
     HostOutgoingValueWithStore, IncomingValueSyncBody,
 };
-use crate::host::{Result, WasiBlobstore, WasiBlobstoreCtxView};
+use crate::host::{OutgoingValue, Result, WasiBlobstore, WasiBlobstoreCtxView};
 
 pub type IncomingValue = Bytes;
-pub type OutgoingValue = MemoryOutputPipe;
 
 impl HostIncomingValueWithStore for WasiBlobstore {
     fn incoming_value_consume_sync<T>(
@@ -67,20 +66,30 @@ impl HostOutgoingValueWithStore for WasiBlobstore {
         accessor: &wasmtime::component::Accessor<T, Self>,
         self_: wasmtime::component::Resource<OutgoingValue>,
     ) -> wasmtime::Result<wasmtime::Result<wasmtime::component::Resource<OutputStream>, ()>> {
-        let value = accessor.with(|mut store| {
-            let outgoing = store.get().table.get(&self_).context("OutgoingValue not found")?;
-            Ok::<_, wasmtime::Error>(outgoing.clone())
-        })?;
-        let stream: OutputStream = Box::new(value);
-        Ok(accessor.with(|mut store| {
-            store.get().table.push(stream).map_err(|e| {
-                tracing::error!("Failed to fetch stream with error {e}");
-            })
-        }))
+        accessor.with(|mut store| {
+            let pipe = {
+                let outgoing = store.get().table.get_mut(&self_).context("OutgoingValue not found")?;
+                if outgoing.take_write_body().is_err() {
+                    return Ok(Err(()));
+                }
+                outgoing.pipe.clone()
+            };
+
+            let stream: OutputStream = Box::new(pipe);
+            let stream_resource = store.get().table.push(stream)?;
+            Ok(Ok(stream_resource))
+        })
     }
 
-    fn finish<T>(_: Access<'_, T, Self>, _self_: Resource<OutgoingValue>) -> Result<()> {
-        Ok(())
+    fn finish<T>(mut host: Access<'_, T, Self>, self_: Resource<OutgoingValue>) -> Result<()> {
+        let outgoing = host
+            .get()
+            .table
+            .get_mut(&self_)
+            .context("OutgoingValue not found")
+            .map_err(|e| e.to_string())?;
+
+        outgoing.finalize().map_err(ToString::to_string)
     }
 
     fn drop<T>(

--- a/deny.toml
+++ b/deny.toml
@@ -26,7 +26,6 @@ allow = [
   "CC0-1.0",
   "CDLA-Permissive-2.0",
   "ISC",
-  "OpenSSL",
   "MIT",
   "MIT-0",
   "Unicode-3.0",
@@ -35,11 +34,6 @@ allow = [
 
 [licenses.private]
 ignore = true
-
-[[licenses.clarify]]
-expression = "MIT AND ISC AND OpenSSL"
-license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
-name = "ring"
 
 [bans]
 deny = [

--- a/examples/blobstore/guest.rs
+++ b/examples/blobstore/guest.rs
@@ -44,11 +44,13 @@ impl Guest for Http {
 async fn handler(body: Bytes) -> HttpResult<Json<Value>> {
     // create an outgoing value to hold the data we want to store
     let outgoing = OutgoingValue::new_outgoing_value();
-    let stream = outgoing
-        .outgoing_value_write_body()
-        .await
-        .map_err(|()| anyhow!("failed to create stream"))?;
-    stream.blocking_write_and_flush(&body).map_err(|e| anyhow!("writing body: {e}"))?;
+    {
+        let stream = outgoing
+            .outgoing_value_write_body()
+            .await
+            .map_err(|()| anyhow!("failed to create stream"))?;
+        stream.blocking_write_and_flush(&body).map_err(|e| anyhow!("writing body: {e}"))?;
+    }
 
     // write the blob to the container
     let container = blobstore::create_container("container".to_string())

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -87,7 +87,7 @@ version = "0.1.13+1.0.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.cc]]
-version = "1.2.56"
+version = "1.2.57"
 criteria = "safe-to-deploy"
 
 [[exemptions.cesu8]]
@@ -295,23 +295,27 @@ version = "2.12.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.iri-string]]
-version = "0.7.10"
+version = "0.7.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.itertools]]
 version = "0.10.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.itertools]]
-version = "0.14.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.itoa]]
-version = "1.0.17"
+version = "1.0.18"
 criteria = "safe-to-deploy"
 
 [[exemptions.jni-sys]]
-version = "0.3.0"
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.jni-sys]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.jni-sys-macros]]
+version = "0.4.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.jobserver]]
@@ -355,7 +359,7 @@ version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.moka]]
-version = "0.12.14"
+version = "0.12.15"
 criteria = "safe-to-deploy"
 
 [[exemptions.munge]]
@@ -364,6 +368,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.munge_macro]]
 version = "0.4.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.num-conv]]
+version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.oauth2]]
@@ -431,7 +439,7 @@ version = "0.2.21"
 criteria = "safe-to-deploy"
 
 [[exemptions.proptest]]
-version = "1.10.0"
+version = "1.11.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.prost]]
@@ -599,7 +607,7 @@ version = "0.8.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.tinyvec]]
-version = "1.10.0"
+version = "1.11.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-rustls]]
@@ -651,7 +659,7 @@ version = "0.32.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tracing-subscriber]]
-version = "0.3.22"
+version = "0.3.23"
 criteria = "safe-to-deploy"
 
 [[exemptions.tungstenite]]
@@ -747,11 +755,11 @@ version = "0.8.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy]]
-version = "0.8.42"
+version = "0.8.47"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy-derive]]
-version = "0.8.42"
+version = "0.8.47"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerotrie]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -16,8 +16,8 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.anstyle]]
-version = "1.0.13"
-when = "2025-09-29"
+version = "1.0.14"
+when = "2026-03-13"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
@@ -156,14 +156,14 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.cmake]]
-version = "0.1.57"
-when = "2025-12-17"
+version = "0.1.58"
+when = "2026-03-26"
 user-id = 55123
 user-login = "rust-lang-owner"
 
 [[publisher.colorchoice]]
-version = "1.0.4"
-when = "2025-06-04"
+version = "1.0.5"
+when = "2026-03-13"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
@@ -1853,6 +1853,15 @@ delta = "0.10.5 -> 0.12.1"
 notes = """
 Minimal `unsafe` usage. Few blocks that existed looked reasonable. Does what it
 says on the tin: lots of iterators.
+"""
+
+[[audits.bytecode-alliance.audits.itertools]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.12.1 -> 0.14.0"
+notes = """
+Lots of new iterators and shuffling some things around. Some new unsafe code but
+it's well-documented and well-tested. Nothing suspicious.
 """
 
 [[audits.bytecode-alliance.audits.leb128]]
@@ -3550,23 +3559,6 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.4.26 -> 0.4.29"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.num-conv]]
-who = "Alex Franchuk <afranchuk@mozilla.com>"
-criteria = "safe-to-deploy"
-version = "0.1.0"
-notes = """
-Very straightforward, simple crate. No dependencies, unsafe, extern,
-side-effectful std functions, etc.
-"""
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.num-conv]]
-who = "Lars Eggert <lars@eggert.org>"
-criteria = "safe-to-deploy"
-delta = "0.1.0 -> 0.2.0"
-notes = "Revision only removes code"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.percent-encoding]]


### PR DESCRIPTION
Build out blobstore capability, including filling gaps in implementation, tests and SDK layer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core WASI blobstore host bindings and resource/lifecycle semantics (streaming `OutgoingValue`, paginated `StreamObjectNames`, `copy_object`/`move_object`), which could affect guest IO behavior across runtimes. Changes are well-covered by new unit/integration-style tests, reducing but not eliminating regression risk.
> 
> **Overview**
> Adds a new `BlobStore` capability to `omnia-sdk`, including container/object metadata types and WASM-default implementations that call through to `omnia-wasi-blobstore` (get/put/delete/list/range reads, container CRUD, and cross-container `copy_object`/`move_object`).
> 
> Completes the host-side `wasi-blobstore` implementation by implementing `copy_object`/`move_object` (with same-source/dest no-op), adding a stateful `StreamObjectNames` for paginated reads, and replacing the raw `MemoryOutputPipe` with an `OutgoingValue` wrapper that enforces one-shot `write_body` and required `finish` semantics. Updates the blobstore guest example accordingly and expands `BlobstoreDefault` tests to cover CRUD, metadata, overwrite/missing cases, copy/move, and streaming pagination.
> 
> Includes minor dependency/policy updates (`omnia-wasi-blobstore` added to the SDK wasm target deps, clippy duplicate-crate allowlist, cargo-deny/vet config adjustments, and lockfile updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d621559c7cf99a86dd2f25253854d44b504ee47. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->