### PR TITLE
Upgrade to wasmtime 43/44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9698bf0769c641b18618039fe2ebd41eb3541f98433000f64e663fab7cea2c87"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
 dependencies = [
  "gimli",
 ]
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -647,6 +647,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,36 +675,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.129.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40630d663279bc855bff805d6f5e8a0b6a1867f9df95b010511ac6dc894e9395"
+version = "0.131.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.129.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee6aec5ceb55e5fdbcf7ef677d7c7195531360ff181ce39b2b31df11d57305f"
+version = "0.131.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.129.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a92d78cc3f087d7e7073828f08d98c7074a3a062b6b29a1b7783ce74305685e"
+version = "0.131.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "cranelift-entity",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.129.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edcc73d756f2e0d7eda6144fe64a2bc69c624de893cb1be51f1442aed77881d2"
+version = "0.131.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "serde",
  "serde_derive",
@@ -704,9 +710,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.129.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d94c2cd0d73b41369b88da1129589bc3a2d99cf49979af1d14751f35b7a1b"
+version = "0.131.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -718,12 +723,12 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "libm",
  "log",
  "pulley-interpreter",
  "regalloc2",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "serde",
  "smallvec",
  "target-lexicon",
@@ -732,9 +737,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.129.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235da0e52ee3a0052d0e944c3470ff025b1f4234f6ec4089d3109f2d2ffa6cbd"
+version = "0.131.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -745,24 +749,21 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.129.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c07c6c440bd1bf920ff7597a1e743ede1f68dcd400730bd6d389effa7662af"
+version = "0.131.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 
 [[package]]
 name = "cranelift-control"
-version = "0.129.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8797c022e02521901e1aee483dea3ed3c67f2bf0a26405c9dd48e8ee7a70944b"
+version = "0.131.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.129.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59d8e72637246edd2cba337939850caa8b201f6315925ec4c156fdd089999699"
+version = "0.131.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -772,9 +773,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.129.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c31db0085c3dfa131e739c3b26f9f9c84d69a9459627aac1ac4ef8355e3411b"
+version = "0.131.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -784,15 +784,13 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.129.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524d804c1ebd8c542e6f64e71aa36934cec17c5da4a9ae3799796220317f5d23"
+version = "0.131.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 
 [[package]]
 name = "cranelift-native"
-version = "0.129.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9598f02540e382e1772416eba18e93c5275b746adbbf06ac1f3cf149415270"
+version = "0.131.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -801,9 +799,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.129.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d953932541249c91e3fa70a75ff1e52adc62979a2a8132145d4b9b3e6d1a9b6a"
+version = "0.131.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 
 [[package]]
 name = "crc32fast"
@@ -1042,8 +1039,8 @@ dependencies = [
  "serde_json",
  "tower-http",
  "tracing",
- "wasip3",
- "wit-bindgen 0.53.1",
+ "wasip3 0.5.0+wasi-0.3.0-rc-2026-03-15",
+ "wit-bindgen 0.54.0",
 ]
 
 [[package]]
@@ -1282,14 +1279,14 @@ dependencies = [
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
- "wasip3",
+ "wasip3 0.4.0+wasi-0.3.0-rc-2026-01-06",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.33.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+checksum = "19e16c5073773ccf057c282be832a59ee53ef5ff98db3aeff7f8314f52ffc196"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",
@@ -1335,7 +1332,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -1345,6 +1341,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1421,9 +1419,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1436,7 +1434,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1451,10 +1448,10 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.6",
 ]
@@ -1523,12 +1520,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1536,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1549,9 +1547,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1563,15 +1561,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1583,15 +1581,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1682,9 +1680,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1776,10 +1774,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1810,9 +1810,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libloading"
@@ -1866,9 +1866,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1950,9 +1950,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -2062,12 +2062,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.37.3"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+checksum = "63944c133d03f44e75866bbd160b95af0ec3f6a13d936d69d31c81078cbc5baf"
 dependencies = [
  "crc32fast",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "indexmap",
  "memchr",
 ]
@@ -2159,8 +2159,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
- "wasip3",
- "wit-bindgen 0.53.1",
+ "wasip3 0.5.0+wasi-0.3.0-rc-2026-03-15",
+ "wit-bindgen 0.54.0",
 ]
 
 [[package]]
@@ -2176,7 +2176,7 @@ dependencies = [
  "tracing",
  "wasmtime",
  "wasmtime-wasi",
- "wit-bindgen 0.53.1",
+ "wit-bindgen 0.54.0",
 ]
 
 [[package]]
@@ -2188,7 +2188,7 @@ dependencies = [
  "tracing",
  "wasmtime",
  "wasmtime-wasi-config",
- "wit-bindgen 0.53.1",
+ "wit-bindgen 0.54.0",
 ]
 
 [[package]]
@@ -2215,7 +2215,7 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
- "wasip3",
+ "wasip3 0.5.0+wasi-0.3.0-rc-2026-03-15",
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
@@ -2236,7 +2236,7 @@ dependencies = [
  "tracing",
  "wasmtime",
  "wasmtime-wasi",
- "wit-bindgen 0.53.1",
+ "wit-bindgen 0.54.0",
 ]
 
 [[package]]
@@ -2257,7 +2257,7 @@ dependencies = [
  "tracing",
  "wasmtime",
  "wasmtime-wasi",
- "wit-bindgen 0.53.1",
+ "wit-bindgen 0.54.0",
 ]
 
 [[package]]
@@ -2275,7 +2275,7 @@ dependencies = [
  "tracing",
  "wasmtime",
  "wasmtime-wasi",
- "wit-bindgen 0.53.1",
+ "wit-bindgen 0.54.0",
 ]
 
 [[package]]
@@ -2293,7 +2293,7 @@ dependencies = [
  "tracing",
  "wasmtime",
  "wasmtime-wasi",
- "wit-bindgen 0.53.1",
+ "wit-bindgen 0.54.0",
 ]
 
 [[package]]
@@ -2317,7 +2317,7 @@ dependencies = [
  "tracing-subscriber",
  "wasmtime",
  "wasmtime-wasi",
- "wit-bindgen 0.53.1",
+ "wit-bindgen 0.54.0",
 ]
 
 [[package]]
@@ -2347,7 +2347,7 @@ dependencies = [
  "tracing",
  "wasmtime",
  "wasmtime-wasi",
- "wit-bindgen 0.53.1",
+ "wit-bindgen 0.54.0",
 ]
 
 [[package]]
@@ -2362,7 +2362,7 @@ dependencies = [
  "tracing",
  "wasmtime",
  "wasmtime-wasi",
- "wit-bindgen 0.53.1",
+ "wit-bindgen 0.54.0",
 ]
 
 [[package]]
@@ -2383,7 +2383,7 @@ dependencies = [
  "tungstenite",
  "wasmtime",
  "wasmtime-wasi",
- "wit-bindgen 0.53.1",
+ "wit-bindgen 0.54.0",
 ]
 
 [[package]]
@@ -2540,12 +2540,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2604,9 +2598,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2705,9 +2699,8 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc2d61e068654529dc196437f8df0981db93687fdc67dec6a5de92363120b9da"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -2717,9 +2710,8 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f210c61b6ecfaebbba806b6d9113a222519d4e5cc4ab2d5ecca047bb7927ae"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2737,8 +2729,8 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
- "rustls 0.23.37",
+ "rustc-hash 2.1.2",
+ "rustls",
  "socket2",
  "thiserror 2.0.18",
  "tokio",
@@ -2758,8 +2750,8 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.1",
- "rustls 0.23.37",
+ "rustc-hash 2.1.2",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -2934,15 +2926,15 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.13.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08effbc1fa53aaebff69521a5c05640523fab037b34a4a2c109506bc938246fa"
+checksum = "952ddbfc6f9f64d006c3efd8c9851a6ba2f2b944ba94730db255d55006e0ffda"
 dependencies = [
  "allocator-api2",
  "bumpalo",
  "hashbrown 0.15.5",
  "log",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "smallvec",
 ]
 
@@ -3006,14 +2998,14 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -3047,12 +3039,12 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -3132,6 +3124,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3139,9 +3137,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -3181,29 +3179,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -3241,10 +3226,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.10",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -3256,17 +3241,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -3711,9 +3685,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3762,22 +3736,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls",
  "tokio",
 ]
 
@@ -4061,9 +4024,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",
@@ -4130,18 +4093,27 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "bytes",
- "http",
- "http-body",
- "thiserror 2.0.18",
  "wit-bindgen 0.51.0",
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.114"
+name = "wasip3"
+version = "0.5.0+wasi-0.3.0-rc-2026-03-15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "1d201c7ba74bcf9d527011d7eb65499cc2a177d3500399fea1134b291873dd08"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "thiserror 2.0.18",
+ "wit-bindgen 0.54.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4152,23 +4124,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4176,9 +4144,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4189,9 +4157,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -4214,6 +4182,16 @@ checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.245.1",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.246.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e1929aad146499e47362c876fcbcbb0363f730951d93438f511178626e999a8"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.246.1",
 ]
 
 [[package]]
@@ -4250,7 +4228,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
- "serde",
 ]
 
 [[package]]
@@ -4266,21 +4243,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmprinter"
-version = "0.244.0"
+name = "wasmparser"
+version = "0.246.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09390d7b2bd7b938e563e4bff10aa345ef2e27a3bc99135697514ef54495e68f"
+checksum = "2d991c35d79bf8336dc1cd632ed4aacf0dc5fac4bc466c670625b037b972bb9c"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.246.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267a5e255a8f9ac8dd403fe6dbfc45f17594b1b7be211c2494c95bfa086d3906"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.244.0",
+ "wasmparser 0.246.1",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bef52be4fb4c5b47d36f847172e896bc94b35c9c6a6f07117686bd16ed89a7"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -4306,7 +4295,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.244.0",
+ "wasmparser 0.246.1",
  "wasmtime-environ",
  "wasmtime-internal-component-macro",
  "wasmtime-internal-component-util",
@@ -4323,26 +4312,29 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb637d5aa960ac391ca5a4cbf3e45807632e56beceeeb530e14dfa67fdfccc62"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "anyhow",
+ "cpp_demangle",
+ "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-entity",
  "gimli",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "indexmap",
  "log",
  "object",
  "postcard",
+ "rustc-demangle",
  "semver",
  "serde",
  "serde_derive",
+ "sha2",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
+ "wasm-encoder 0.246.1",
+ "wasmparser 0.246.1",
  "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
@@ -4350,9 +4342,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca768b11d5e7de017e8c3d4d444da6b4ce3906f565bcbc253d76b4ecbb5d2869"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4360,30 +4351,29 @@ dependencies = [
  "syn",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.244.0",
+ "wit-parser 0.246.1",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763f504faf96c9b409051e96a1434655eea7f56a90bed9cb1e22e22c941253fd"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a4a3f055a804a2f3d86e816a9df78a8fa57762212a8506164959224a40cd48"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "anyhow",
+ "hashbrown 0.16.1",
  "libm",
+ "serde",
 ]
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55154a91d22ad51f9551124ce7fb49ddddc6a82c4910813db4c790c97c9ccf32"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4399,7 +4389,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.244.0",
+ "wasmparser 0.246.1",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -4408,9 +4398,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05decfad1021ad2efcca5c1be9855acb54b6ee7158ac4467119b30b7481508e3"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "cc",
  "cfg-if",
@@ -4423,9 +4412,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924980c50427885fd4feed2049b88380178e567768aaabf29045b02eb262eaa7"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros",
@@ -4433,9 +4421,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c57d24e8d1334a0e5a8b600286ffefa1fc4c3e8176b110dff6fbc1f43c4a599b"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4445,9 +4432,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1a144bd4393593a868ba9df09f34a6a360cb5db6e71815f20d3f649c6e6735"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4458,9 +4444,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a6948b56bb00c62dbd205ea18a4f1ceccbe1e4b8479651fdb0bab2553790f20"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4469,16 +4454,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9130b3ab6fb01be80b27b9a2c84817af29ae8224094f2503d2afa9fea5bf9d00"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "cranelift-codegen",
  "gimli",
  "log",
  "object",
  "target-lexicon",
- "wasmparser 0.244.0",
+ "wasmparser 0.246.1",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -4486,22 +4470,20 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102d0d70dbfede00e4cc9c24e86df6d32c03bf6f5ad06b5d6c76b0a4a5004c4a"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "anyhow",
  "bitflags",
  "heck",
  "indexmap",
- "wit-parser 0.244.0",
+ "wit-parser 0.246.1",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea938f6f4f11e5ffe6d8b6f34c9a994821db9511c3e9c98e535896f27d06bb92"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -4529,18 +4511,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4098f2946fa6a62adc001554f5f4039a3c7f8e46738bf89a3279cdf9ef650cc"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "wasmtime",
 ]
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fdc8d790eb6505a911489b72671de8d84330b621329283e34f2a46d15c3e6dd"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4549,9 +4529,9 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "rustls 0.22.4",
+ "rustls",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls",
  "tokio-util",
  "tracing",
  "wasmtime",
@@ -4562,9 +4542,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71cb16a88d0443b509d6eca4298617233265179090abf03e0a8042b9b251e9da"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4584,9 +4563,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4631,9 +4610,8 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dca2bf96d20f0c70e6741cc6c8c1a9ee4c3c0310c7ad1971242628c083cc9a5"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "bitflags",
  "thiserror 2.0.18",
@@ -4645,9 +4623,8 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d8c016d6d3ec6dc6b8c80c23cede4ee2386ccf347d01984f7991d7659f73ef"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4659,9 +4636,8 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91a267096e48857096f035fffca29e22f0bbe840af4d74a6725eb695e1782110"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4702,9 +4678,8 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "42.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1977857998e4dd70d26e2bfc0618a9684a2fb65b1eca174dc13f3b3e9c2159ca"
+version = "44.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",
@@ -4713,7 +4688,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.244.0",
+ "wasmparser 0.246.1",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
@@ -5059,19 +5034,18 @@ version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
- "futures",
  "wit-bindgen-rust-macro 0.51.0",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.53.1"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e915216dde3e818093168df8380a64fba25df468d626c80dd5d6a184c87e7c7"
+checksum = "2bb00254d5051d69730ee32580b7373592f10ad786757c372f0f2c7b61f86a2c"
 dependencies = [
  "bitflags",
  "futures",
- "wit-bindgen-rust-macro 0.53.1",
+ "wit-bindgen-rust-macro 0.54.0",
 ]
 
 [[package]]
@@ -5087,9 +5061,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.53.1"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deda4b7e9f522d994906f6e6e0fc67965ea8660306940a776b76732be8f3933"
+checksum = "99cdef5ccf0b0e9bf30868d6f9c5ed116c84ae95f84ba29d2216d3e922de3963"
 dependencies = [
  "anyhow",
  "heck",
@@ -5114,9 +5088,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.53.1"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "863a7ab3c4dfee58db196811caeb0718b88412a0aef3d1c2b02fcbae1e37c688"
+checksum = "e76541e2f37ac1729db85765729daa0f3c2b5975d66699114d107525f6d6c8d5"
 dependencies = [
  "anyhow",
  "heck",
@@ -5124,7 +5098,7 @@ dependencies = [
  "prettyplease",
  "syn",
  "wasm-metadata 0.245.1",
- "wit-bindgen-core 0.53.1",
+ "wit-bindgen-core 0.54.0",
  "wit-component 0.245.1",
 ]
 
@@ -5145,17 +5119,17 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.53.1"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14f3a9bfa3804bb0e9ab7f66da047f210eded6a1297ae3ba5805b384d64797f"
+checksum = "a284e17b2bc808c72ba008f6694626fa76bcac608b3d1ed0880f9add3f558f8e"
 dependencies = [
  "anyhow",
  "prettyplease",
  "proc-macro2",
  "quote",
  "syn",
- "wit-bindgen-core 0.53.1",
- "wit-bindgen-rust 0.53.1",
+ "wit-bindgen-core 0.54.0",
+ "wit-bindgen-rust 0.54.0",
 ]
 
 [[package]]
@@ -5234,6 +5208,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-parser"
+version = "0.246.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc133164d0fa0a990756d5cdb1a4c24e1f638643e1f3e085d0e51111968e8536"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.16.1",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.246.1",
+]
+
+[[package]]
 name = "witx"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5262,9 +5255,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5273,9 +5266,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5285,18 +5278,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5305,18 +5298,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5332,9 +5325,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5343,9 +5336,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5354,9 +5347,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,13 +87,13 @@ tower = "0.5.3"
 tracing = "0.1.44"
 tracing-opentelemetry = "0.32.1"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter", "fmt"] }
-wasip3 = { version = "0.4.0", features = ["http-compat"] }
-wasmtime = { version = "42.0.1", default-features = false, features = ["anyhow", "parallel-compilation"] }
-wasmtime-wasi = { version = "42.0.1", features = ["p3"] }
-wasmtime-wasi-config = "42.0.1"
-wasmtime-wasi-http = { version = "42.0.1", features = ["p3"] }
-wasmtime-wasi-io = "42.0.1"
-wit-bindgen = { version = "0.53.1", features = ["async-spawn"] }
+wasip3 = { version = "0.5.0", features = ["http-compat"] }
+wasmtime = { version = "44.0.0", default-features = false, features = ["anyhow", "parallel-compilation"] }
+wasmtime-wasi = { version = "44.0.0", features = ["p3"] }
+wasmtime-wasi-config = "44.0.0"
+wasmtime-wasi-http = { version = "44.0.0", features = ["p3"] }
+wasmtime-wasi-io = "44.0.0"
+wit-bindgen = { version = "0.54.0", features = ["async-spawn"] }
 
 # internally referenced crates
 omnia = { path = "crates/omnia", version = "0.30.0" }
@@ -106,12 +106,12 @@ omnia-wasi-blobstore = { path = "crates/wasi-blobstore", version = "0.30.0" }
 omnia-wasi-config = { path = "crates/wasi-config", version = "0.30.0" }
 omnia-wasi-http = { path = "crates/wasi-http", version = "0.30.0" }
 omnia-wasi-identity = { path = "crates/wasi-identity", version = "0.30.0" }
+omnia-wasi-jsondb = { path = "crates/wasi-jsondb", version = "0.30.0" }
 omnia-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "0.30.0" }
 omnia-wasi-messaging = { path = "crates/wasi-messaging", version = "0.30.0" }
 omnia-wasi-otel = { path = "crates/wasi-otel", version = "0.30.0" }
 omnia-wasi-otel-attr = { path = "crates/wasi-otel-attr", version = "0.30.0" }
 omnia-wasi-sql = { path = "crates/wasi-sql", version = "0.30.0" }
-omnia-wasi-jsondb = { path = "crates/wasi-jsondb", version = "0.30.0" }
 omnia-wasi-vault = { path = "crates/wasi-vault", version = "0.30.0" }
 omnia-wasi-websocket = { path = "crates/wasi-websocket", version = "0.30.0" }
 
@@ -126,9 +126,10 @@ strip = true
 # [package.metadata.cargo-machete]
 # ignored = ["openssl"]
 
-# [patch.crates-io]
-# wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", branch = "release-42.0.0" }
-# wasmtime-wasi = { git = "https://github.com/bytecodealliance/wasmtime", branch = "release-42.0.0" }
-# wasmtime-wasi-config = { git = "https://github.com/bytecodealliance/wasmtime", branch = "release-42.0.0" }
-# wasmtime-wasi-http = { git = "https://github.com/bytecodealliance/wasmtime", branch = "release-42.0.0" }
-# wasmtime-wasi-io = { git = "https://github.com/bytecodealliance/wasmtime", branch = "release-42.0.0" }
+# TODO: remove once wasmtime 44 is published on crates.io
+[patch.crates-io]
+wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", branch = "main" }
+wasmtime-wasi = { git = "https://github.com/bytecodealliance/wasmtime", branch = "main" }
+wasmtime-wasi-config = { git = "https://github.com/bytecodealliance/wasmtime", branch = "main" }
+wasmtime-wasi-http = { git = "https://github.com/bytecodealliance/wasmtime", branch = "main" }
+wasmtime-wasi-io = { git = "https://github.com/bytecodealliance/wasmtime", branch = "main" }

--- a/clippy.toml
+++ b/clippy.toml
@@ -43,6 +43,7 @@ allowed-duplicate-crates = [
   "windows_x86_64_gnu",
   "windows_x86_64_gnullvm",
   "windows_x86_64_msvc",
+  "wasip3",
   "wit-bindgen",
   "wit-bindgen-core",
   "wit-bindgen-rust",

--- a/crates/omnia-sdk/src/capabilities.rs
+++ b/crates/omnia-sdk/src/capabilities.rs
@@ -511,9 +511,9 @@ pub trait BlobStore: Send + Sync {
                 let body = outgoing
                     .outgoing_value_write_body()
                     .await
-                    .map_err(|e| anyhow!("getting write body: {e}"))?;
+                    .map_err(|e| anyhow!("getting write body: {e:?}"))?;
                 body.blocking_write_and_flush(data).map_err(|e| anyhow!("writing data: {e}"))?;
-            }
+            };
             ctr.write_data(name.to_string(), &outgoing)
                 .await
                 .map_err(|e| anyhow!("writing object: {e}"))?;
@@ -635,7 +635,7 @@ pub trait BlobStore: Send + Sync {
             let ctr = blobstore::get_container(container.to_string())
                 .await
                 .map_err(|e| anyhow!("opening container: {e}"))?;
-            ctr.delete_objects(&names).await.map_err(|e| anyhow!("deleting objects: {e}"))
+            ctr.delete_objects(names).await.map_err(|e| anyhow!("deleting objects: {e}"))
         }
     }
 
@@ -728,7 +728,7 @@ pub trait BlobStore: Send + Sync {
                 container: dest_container.to_string(),
                 object: dest_name.to_string(),
             };
-            blobstore::copy_object(&src, &dest).await.map_err(|e| anyhow!("copying object: {e}"))
+            blobstore::copy_object(src, dest).await.map_err(|e| anyhow!("copying object: {e}"))
         }
     }
 
@@ -752,7 +752,7 @@ pub trait BlobStore: Send + Sync {
                 container: dest_container.to_string(),
                 object: dest_name.to_string(),
             };
-            blobstore::move_object(&src, &dest).await.map_err(|e| anyhow!("moving object: {e}"))
+            blobstore::move_object(src, dest).await.map_err(|e| anyhow!("moving object: {e}"))
         }
     }
 }

--- a/crates/wasi-http/src/host.rs
+++ b/crates/wasi-http/src/host.rs
@@ -9,6 +9,7 @@ use anyhow::Result;
 pub use default_impl::HttpDefault;
 use omnia::{Host, Server, State};
 use wasmtime::component::Linker;
+pub use wasmtime_wasi_http::WasiHttpCtx;
 pub use wasmtime_wasi_http::p3::{WasiHttpCtxView, WasiHttpView};
 
 /// Host-side service for `wasi:http`.
@@ -40,10 +41,7 @@ macro_rules! omnia_wasi_view {
     ($store_ctx:ty, $field_name:ident) => {
         impl omnia_wasi_http::WasiHttpView for $store_ctx {
             fn http(&mut self) -> omnia_wasi_http::WasiHttpCtxView<'_> {
-                omnia_wasi_http::WasiHttpCtxView {
-                    ctx: &mut self.$field_name,
-                    table: &mut self.table,
-                }
+                self.$field_name.as_view(&mut self.table)
             }
         }
     };

--- a/crates/wasi-http/src/host/default_impl.rs
+++ b/crates/wasi-http/src/host/default_impl.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use base64ct::{Base64, Encoding};
@@ -14,15 +15,17 @@ use http_body_util::BodyExt;
 use http_body_util::combinators::UnsyncBoxBody;
 use omnia::Backend;
 use tracing::instrument;
+use wasmtime::component::ResourceTable;
 use wasmtime_wasi::TrappableError;
+use wasmtime_wasi_http::WasiHttpCtx;
 use wasmtime_wasi_http::p3::bindings::http::types::ErrorCode;
-use wasmtime_wasi_http::p3::{self, RequestOptions};
+use wasmtime_wasi_http::p3::{self, RequestOptions, WasiHttpCtxView};
 
 pub type HttpResult<T> = Result<T, HttpError>;
 pub type HttpError = TrappableError<ErrorCode>;
 pub type FutureResult<T> = Box<dyn Future<Output = Result<T, ErrorCode>> + Send>;
 
-/// Set of headers that are forbidden by by `wasmtime-wasi-http`.
+/// Set of headers that are forbidden by `wasmtime-wasi-http`.
 pub const FORBIDDEN_HEADERS: [HeaderName; 9] = [
     CONNECTION,
     HOST,
@@ -39,6 +42,8 @@ pub const FORBIDDEN_HEADERS: [HeaderName; 9] = [
 pub struct ConnectOptions {
     #[env(from = "HTTP_ADDR", default = "http://localhost:8080")]
     pub addr: String,
+    #[env(from = "HTTP_CONNECT_TIMEOUT_SECS", default = "10")]
+    pub connect_timeout_secs: u64,
 }
 
 impl omnia::FromEnv for ConnectOptions {
@@ -47,20 +52,55 @@ impl omnia::FromEnv for ConnectOptions {
     }
 }
 
+/// Reqwest-based HTTP hooks for outbound `wasi:http` requests.
+#[derive(Debug, Clone)]
+struct HttpHooks {
+    client: reqwest::Client,
+    connect_timeout: Duration,
+}
+
 /// Default implementation for `wasi:http`.
 #[derive(Debug, Clone)]
-pub struct HttpDefault;
+pub struct HttpDefault {
+    hooks: HttpHooks,
+    ctx: WasiHttpCtx,
+}
+
+impl HttpDefault {
+    /// Produce a [`WasiHttpCtxView`] by splitting borrows on inner fields.
+    pub fn as_view<'a>(&'a mut self, table: &'a mut ResourceTable) -> WasiHttpCtxView<'a> {
+        WasiHttpCtxView {
+            hooks: &mut self.hooks,
+            ctx: &mut self.ctx,
+            table,
+        }
+    }
+}
 
 impl Backend for HttpDefault {
     type ConnectOptions = ConnectOptions;
 
     #[instrument]
     async fn connect_with(options: Self::ConnectOptions) -> Result<Self> {
-        Ok(Self)
+        let connect_timeout = Duration::from_secs(options.connect_timeout_secs);
+
+        let builder = reqwest::Client::builder().connect_timeout(connect_timeout);
+
+        #[cfg(test)]
+        let builder = builder.no_proxy();
+
+        let client = builder.build().context("building HTTP client")?;
+        Ok(Self {
+            hooks: HttpHooks {
+                client,
+                connect_timeout,
+            },
+            ctx: WasiHttpCtx::default(),
+        })
     }
 }
 
-impl p3::WasiHttpCtx for HttpDefault {
+impl p3::WasiHttpHooks for HttpHooks {
     fn send_request(
         &mut self, request: Request<UnsyncBoxBody<Bytes, ErrorCode>>,
         _options: Option<RequestOptions>, fut: FutureResult<()>,
@@ -69,6 +109,9 @@ impl p3::WasiHttpCtx for HttpDefault {
                 Output = HttpResult<(Response<UnsyncBoxBody<Bytes, ErrorCode>>, FutureResult<()>)>,
             > + Send,
     > {
+        let shared_client = self.client.clone();
+        let connect_timeout = self.connect_timeout;
+
         Box::new(async move {
             let (mut parts, body) = request.into_parts();
 
@@ -81,28 +124,30 @@ impl p3::WasiHttpCtx for HttpDefault {
                 }
             }
 
-            // build client
-            let mut builder = reqwest::Client::builder();
-
-            // check for "Client-Cert" header
-            if let Some(encoded_cert) = parts.headers.remove("Client-Cert") {
+            // use a one-off client when a client certificate is required, otherwise
+            // reuse the shared client for connection pooling
+            let client = if let Some(encoded_cert) = parts.headers.remove("Client-Cert") {
                 tracing::debug!("using client certificate");
                 let encoded = encoded_cert.to_str().map_err(internal_err)?;
                 let bytes = Base64::decode_vec(encoded).map_err(internal_err)?;
                 let identity = reqwest::Identity::from_pem(&bytes).map_err(internal_err)?;
-                builder = builder.identity(identity);
-            }
+                let builder =
+                    reqwest::Client::builder().connect_timeout(connect_timeout).identity(identity);
 
-            // disable system proxy in tests to avoid macOS issues
-            #[cfg(test)]
-            let builder = builder.no_proxy();
-            let client = builder.build().map_err(reqwest_err)?;
+                #[cfg(test)]
+                let builder = builder.no_proxy();
+
+                builder.build().map_err(reqwest_err)?
+            } else {
+                shared_client
+            };
 
             let collected = body.collect().await.map_err(internal_err)?;
 
             // make request
+            let url = parts.uri.to_string();
             let resp = client
-                .request(parts.method, parts.uri.to_string())
+                .request(parts.method, &url)
                 .headers(parts.headers)
                 .body(collected.to_bytes())
                 .send()
@@ -150,11 +195,19 @@ mod tests {
     use http::header::{AUTHORIZATION, CONTENT_TYPE};
     use http::{Method, StatusCode};
     use http_body_util::{Empty, Full};
-    use p3::WasiHttpCtx;
+    use p3::WasiHttpHooks;
     use wiremock::matchers::{body_string, header, method};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::*;
+
+    async fn test_client() -> HttpDefault {
+        let options = ConnectOptions {
+            addr: String::new(),
+            connect_timeout_secs: 10,
+        };
+        HttpDefault::connect_with(options).await.unwrap()
+    }
 
     #[tokio::test]
     async fn multiple_host_headers() {
@@ -170,7 +223,7 @@ mod tests {
             .body(Empty::new().map_err(internal_err).boxed_unsync())
             .unwrap();
 
-        let result = HttpDefault.handle(request).await;
+        let result = test_client().await.handle(request).await;
         assert!(result.is_ok());
 
         // check response
@@ -202,7 +255,7 @@ mod tests {
             .body(Full::new(Bytes::from("test body")).map_err(internal_err).boxed_unsync())
             .unwrap();
 
-        let result = HttpDefault.handle(request).await;
+        let result = test_client().await.handle(request).await;
         assert!(result.is_ok());
 
         let (response, _) = result.unwrap();
@@ -225,7 +278,7 @@ mod tests {
             .body(Empty::new().map_err(internal_err).boxed_unsync())
             .unwrap();
 
-        let result = HttpDefault.handle(request).await;
+        let result = test_client().await.handle(request).await;
         assert!(result.is_ok());
 
         let (response, _) = result.unwrap();
@@ -251,7 +304,7 @@ mod tests {
             .body(Empty::new().map_err(internal_err).boxed_unsync())
             .unwrap();
 
-        let result = HttpDefault.handle(request).await;
+        let result = test_client().await.handle(request).await;
         assert!(result.is_ok());
 
         // check response
@@ -274,7 +327,7 @@ mod tests {
         let request =
             Request::builder().method(Method::GET).uri("not-a-valid-uri").body(body).unwrap();
 
-        let result = HttpDefault.handle(request).await;
+        let result = test_client().await.handle(request).await;
         assert!(result.is_err());
     }
 
@@ -284,7 +337,7 @@ mod tests {
             .body(Empty::new().map_err(internal_err).boxed_unsync())
             .unwrap();
 
-        let result = HttpDefault.handle(request).await;
+        let result = test_client().await.handle(request).await;
         assert!(result.is_err());
     }
 
@@ -298,7 +351,7 @@ mod tests {
             .body(Empty::new().map_err(internal_err).boxed_unsync())
             .unwrap();
 
-        let result = HttpDefault.handle(request).await;
+        let result = test_client().await.handle(request).await;
         assert!(result.is_err());
     }
 
@@ -314,16 +367,15 @@ mod tests {
             .body(Empty::new().map_err(internal_err).boxed_unsync())
             .unwrap();
 
-        let result = HttpDefault.handle(request).await;
+        let result = test_client().await.handle(request).await;
         assert!(result.is_err());
     }
 
-    // Mock `wasip3::proxy::wasi::http::handler::handle` method
     impl HttpDefault {
         async fn handle(
             &mut self, request: Request<UnsyncBoxBody<Bytes, ErrorCode>>,
         ) -> HttpResult<(Response<UnsyncBoxBody<Bytes, ErrorCode>>, FutureResult<()>)> {
-            let boxed = self.send_request(request, None, Box::new(async { Ok(()) }));
+            let boxed = self.hooks.send_request(request, None, Box::new(async { Ok(()) }));
             Pin::from(boxed).await
         }
     }

--- a/crates/wasi-http/src/host/server.rs
+++ b/crates/wasi-http/src/host/server.rs
@@ -3,7 +3,9 @@
 use std::clone::Clone;
 use std::convert::Infallible;
 use std::env;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context as TaskContext, Poll};
 
 use anyhow::{Context, Result, anyhow};
 use bytes::Bytes;
@@ -11,7 +13,7 @@ use http::StatusCode;
 use http::uri::{PathAndQuery, Uri};
 use http_body_util::combinators::UnsyncBoxBody;
 use http_body_util::{BodyExt, Full};
-use hyper::body::Incoming;
+use hyper::body::{Body, Frame, Incoming, SizeHint};
 use hyper::header::{FORWARDED, HOST};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
@@ -119,41 +121,66 @@ where
         let instance = instance_pre.instantiate_async(&mut store).await?;
         let service = indices.load(&mut store, &instance)?;
 
-        let (sender, receiver) = oneshot::channel();
+        let (sender, receiver) = oneshot::channel::<Result<hyper::Response<OutgoingBody>>>();
 
         tokio::spawn(async move {
-            let guest_result = store
+            let send_err = |sender: oneshot::Sender<_>, e: anyhow::Error| {
+                _ = sender.send(Err(e));
+            };
+
+            let result = store
                 .run_concurrent(async |store| {
                     // convert hyper::Request to wasi::Request
                     let (parts, body) = request.into_parts();
                     let body = body.map_err(ErrorCode::from_hyper_request_error);
                     let http_req = http::Request::from_parts(parts, body);
-                    let (request, io_result) = wasi::Request::from_http(http_req);
+                    let (request, io) = wasi::Request::from_http(http_req);
 
                     // forward request to guest
-                    let (wasi_resp, task) = service.handle(store, request).await??;
-                    let http_resp =
-                        store.with(|mut store| wasi_resp.into_http(&mut store, io_result))?;
-                    _ = sender.send(http_resp);
-                    task.block(store).await;
+                    let wasi_resp = match service.handle(store, request).await? {
+                        Ok(resp) => resp,
+                        Err(e) => {
+                            send_err(sender, anyhow!("guest error: {e}"));
+                            return anyhow::Ok(());
+                        }
+                    };
+                    let resp = match store.with(|mut store| wasi_resp.into_http(&mut store, io)) {
+                        Ok(resp) => resp,
+                        Err(e) => {
+                            send_err(sender, anyhow!("converting guest response: {e}"));
+                            return anyhow::Ok(());
+                        }
+                    };
+
+                    // wrap body so we can detect when hyper finishes consuming it
+                    let (body_done_tx, body_done_rx) = oneshot::channel::<()>();
+                    let resp = resp.map(|body| {
+                        BodyDoneWrapper {
+                            body: body.map_err(Into::into),
+                            _tx: body_done_tx,
+                        }
+                        .boxed_unsync()
+                    });
+
+                    // send the streaming response to hyper, then keep
+                    // run_concurrent alive until hyper finishes reading
+                    if sender.send(Ok(resp)).is_ok() {
+                        _ = body_done_rx.await;
+                    }
 
                     anyhow::Ok(())
                 })
                 .instrument(debug_span!("http-request"))
-                .await?;
+                .await;
 
-            if let Err(e) = guest_result {
-                tracing::error!("Guest error: {e:?}");
-                return Err(e);
+            match result {
+                Err(e) => tracing::error!("run_concurrent error: {e:?}"),
+                Ok(Err(e)) => tracing::error!("guest error: {e:#}"),
+                Ok(Ok(())) => {}
             }
-
-            // write_profile(&mut store);
-            // drop(epoch_thread);
-
-            Ok(())
         });
 
-        let response = receiver.await?.map(|body| body.map_err(Into::into).boxed_unsync());
+        let response = receiver.await.map_err(|_recv| anyhow!("guest task panicked"))??;
         tracing::debug!("received response: {response:?}");
 
         Ok(response)
@@ -194,6 +221,38 @@ fn fix_request(mut request: hyper::Request<Incoming>) -> Result<hyper::Request<I
     let request = hyper::Request::from_parts(parts, body);
 
     Ok(request)
+}
+
+/// Wraps a response body and holds a `oneshot::Sender` that is dropped when
+/// the body is fully consumed (or the wrapper itself is dropped). The
+/// corresponding receiver keeps `run_concurrent` alive so WASI pipe resources
+/// remain valid while hyper streams the response.
+struct BodyDoneWrapper<B> {
+    body: B,
+    _tx: oneshot::Sender<()>,
+}
+
+impl<B> Body for BodyDoneWrapper<B>
+where
+    B: Body + Unpin,
+{
+    type Data = B::Data;
+    type Error = B::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>, cx: &mut TaskContext<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let inner = Pin::new(&mut self.get_mut().body);
+        inner.poll_frame(cx)
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.body.size_hint()
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.body.is_end_stream()
+    }
 }
 
 const BODY: &str = r"<!doctype html>

--- a/deny.toml
+++ b/deny.toml
@@ -35,6 +35,9 @@ allow = [
 [licenses.private]
 ignore = true
 
+[sources]
+allow-git = ["https://github.com/bytecodealliance/wasmtime"]
+
 [bans]
 deny = [
   { name = "tokio", deny-multiple-versions = true },

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -335,13 +335,13 @@ end = "2026-09-11"
 
 [[trusted.icu_properties]]
 criteria = "safe-to-deploy"
-user-id = 166196 # Robert Bastian (robertbastian)
+user-id = 166196
 start = "2023-01-26"
 end = "2026-12-11"
 
 [[trusted.icu_properties_data]]
 criteria = "safe-to-deploy"
-user-id = 166196 # Robert Bastian (robertbastian)
+user-id = 166196
 start = "2023-11-16"
 end = "2026-12-11"
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -23,7 +23,7 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"
 
 [[exemptions.addr2line]]
-version = "0.25.1"
+version = "0.26.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.ahash]]
@@ -39,7 +39,7 @@ version = "1.16.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.aws-lc-sys]]
-version = "0.39.0"
+version = "0.39.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.axum]]
@@ -87,7 +87,7 @@ version = "0.1.13+1.0.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.cc]]
-version = "1.2.57"
+version = "1.2.58"
 criteria = "safe-to-deploy"
 
 [[exemptions.cesu8]]
@@ -112,6 +112,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.core-foundation]]
 version = "0.10.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cpp_demangle]]
+version = "0.4.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.cpufeatures]]
@@ -255,7 +259,7 @@ version = "0.4.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.gimli]]
-version = "0.33.0"
+version = "0.33.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.hashbrown]]
@@ -282,6 +286,34 @@ criteria = "safe-to-deploy"
 version = "0.1.65"
 criteria = "safe-to-deploy"
 
+[[exemptions.icu_collections]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_locale_core]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_normalizer]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_normalizer_data]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_properties]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_properties_data]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.icu_provider]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.id-arena]]
 version = "2.3.0"
 criteria = "safe-to-deploy"
@@ -295,7 +327,7 @@ version = "2.12.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.iri-string]]
-version = "0.7.11"
+version = "0.7.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.itertools]]
@@ -323,7 +355,7 @@ version = "0.1.34"
 criteria = "safe-to-deploy"
 
 [[exemptions.js-sys]]
-version = "0.3.91"
+version = "0.3.94"
 criteria = "safe-to-deploy"
 
 [[exemptions.lazycell]]
@@ -340,6 +372,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.libz-sys]]
 version = "1.1.25"
+criteria = "safe-to-deploy"
+
+[[exemptions.litemap]]
+version = "0.8.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.lru-slab]]
@@ -379,7 +415,7 @@ version = "5.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.object]]
-version = "0.37.3"
+version = "0.39.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.once_cell]]
@@ -514,8 +550,8 @@ criteria = "safe-to-deploy"
 version = "0.39.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.rustls]]
-version = "0.22.4"
+[[exemptions.rustc-hash]]
+version = "2.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls]]
@@ -536,10 +572,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.rustls-platform-verifier-android]]
 version = "0.1.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.rustls-webpki]]
-version = "0.102.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls-webpki]]
@@ -603,15 +635,11 @@ version = "0.3.47"
 criteria = "safe-to-deploy"
 
 [[exemptions.tinystr]]
-version = "0.8.2"
+version = "0.8.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.tinyvec]]
 version = "1.11.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.tokio-rustls]]
-version = "0.25.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-rustls]]
@@ -679,7 +707,7 @@ version = "0.9.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.uuid]]
-version = "1.22.0"
+version = "1.23.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.version_check]]
@@ -691,27 +719,27 @@ version = "2.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen]]
-version = "0.2.114"
+version = "0.2.117"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-futures]]
-version = "0.4.64"
+version = "0.4.67"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro]]
-version = "0.2.114"
+version = "0.2.117"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro-support]]
-version = "0.2.114"
+version = "0.2.117"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-shared]]
-version = "0.2.114"
+version = "0.2.117"
 criteria = "safe-to-deploy"
 
 [[exemptions.web-sys]]
-version = "0.3.91"
+version = "0.3.94"
 criteria = "safe-to-deploy"
 
 [[exemptions.web-time]]
@@ -751,23 +779,39 @@ version = "0.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.yoke]]
-version = "0.8.1"
+version = "0.8.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.yoke-derive]]
+version = "0.8.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy]]
-version = "0.8.47"
+version = "0.8.48"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy-derive]]
-version = "0.8.47"
+version = "0.8.48"
+criteria = "safe-to-deploy"
+
+[[exemptions.zerofrom]]
+version = "0.1.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.zerofrom-derive]]
+version = "0.1.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerotrie]]
-version = "0.2.3"
+version = "0.2.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerovec]]
-version = "0.11.5"
+version = "0.11.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.zerovec-derive]]
+version = "0.11.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.zmij]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -175,71 +175,6 @@ user-id = 5946
 user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
-[[publisher.cranelift-assembler-x64]]
-version = "0.129.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.cranelift-assembler-x64-meta]]
-version = "0.129.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.cranelift-bforest]]
-version = "0.129.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.cranelift-bitset]]
-version = "0.129.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.cranelift-codegen]]
-version = "0.129.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.cranelift-codegen-meta]]
-version = "0.129.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.cranelift-codegen-shared]]
-version = "0.129.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.cranelift-control]]
-version = "0.129.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.cranelift-entity]]
-version = "0.129.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.cranelift-frontend]]
-version = "0.129.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.cranelift-isle]]
-version = "0.129.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.cranelift-native]]
-version = "0.129.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.cranelift-srcgen]]
-version = "0.129.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
 [[publisher.encoding_rs]]
 version = "0.8.35"
 when = "2024-10-24"
@@ -309,8 +244,8 @@ user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
 [[publisher.hyper]]
-version = "1.8.1"
-when = "2025-11-13"
+version = "1.9.0"
+when = "2026-03-31"
 user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
@@ -321,20 +256,6 @@ when = "2026-02-02"
 user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
-
-[[publisher.icu_properties]]
-version = "2.1.2"
-when = "2025-12-09"
-user-id = 166196
-user-login = "robertbastian"
-user-name = "Robert Bastian"
-
-[[publisher.icu_properties_data]]
-version = "2.1.2"
-when = "2025-12-09"
-user-id = 166196
-user-login = "robertbastian"
-user-name = "Robert Bastian"
 
 [[publisher.idna]]
 version = "1.0.2"
@@ -372,8 +293,8 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.libc]]
-version = "0.2.183"
-when = "2026-03-08"
+version = "0.2.184"
+when = "2026-04-01"
 user-id = 55123
 user-login = "rust-lang-owner"
 
@@ -426,8 +347,8 @@ user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
 [[publisher.mio]]
-version = "1.1.1"
-when = "2025-12-04"
+version = "1.2.0"
+when = "2026-03-27"
 user-id = 6025
 user-login = "Thomasdezeeuw"
 user-name = "Thomas de Zeeuw"
@@ -454,8 +375,8 @@ user-login = "Amanieu"
 user-name = "Amanieu d'Antras"
 
 [[publisher.potential_utf]]
-version = "0.1.4"
-when = "2025-10-28"
+version = "0.1.5"
+when = "2026-04-01"
 user-id = 1139
 user-login = "Manishearth"
 user-name = "Manish Goregaokar"
@@ -474,16 +395,6 @@ user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
-[[publisher.pulley-interpreter]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.pulley-macros]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
 [[publisher.quote]]
 version = "1.0.45"
 when = "2026-03-03"
@@ -492,8 +403,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.regalloc2]]
-version = "0.13.5"
-when = "2026-01-09"
+version = "0.15.0"
+when = "2026-02-17"
 user-id = 3726
 user-login = "cfallin"
 user-name = "Chris Fallin"
@@ -532,6 +443,12 @@ when = "2026-02-06"
 user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
+
+[[publisher.rustc-demangle]]
+version = "0.1.27"
+when = "2026-01-15"
+user-id = 55123
+user-login = "rust-lang-owner"
 
 [[publisher.rustix]]
 version = "0.38.44"
@@ -757,6 +674,13 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wasip3]]
+version = "0.5.0+wasi-0.3.0-rc-2026-03-15"
+when = "2026-04-01"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.wasm-encoder]]
 version = "0.236.0"
 when = "2025-07-28"
@@ -766,6 +690,11 @@ user-login = "wasmtime-publish"
 [[publisher.wasm-encoder]]
 version = "0.245.1"
 when = "2026-02-12"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+
+[[publisher.wasm-encoder]]
+version = "0.246.1"
+when = "2026-03-31"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasm-metadata]]
@@ -788,112 +717,17 @@ user-login = "wasmtime-publish"
 [[publisher.wasmparser]]
 version = "0.245.1"
 when = "2026-02-12"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+
+[[publisher.wasmparser]]
+version = "0.246.1"
+when = "2026-03-31"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmprinter]]
-version = "0.244.0"
-when = "2026-01-06"
+version = "0.246.1"
+when = "2026-03-31"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
-
-[[publisher.wasmtime]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.wasmtime-environ]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.wasmtime-internal-component-macro]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.wasmtime-internal-component-util]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.wasmtime-internal-core]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.wasmtime-internal-cranelift]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.wasmtime-internal-fiber]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.wasmtime-internal-jit-debug]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.wasmtime-internal-jit-icache-coherence]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.wasmtime-internal-unwinder]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.wasmtime-internal-versioned-export-macros]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.wasmtime-internal-winch]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.wasmtime-internal-wit-bindgen]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.wasmtime-wasi]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.wasmtime-wasi-config]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.wasmtime-wasi-http]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.wasmtime-wasi-io]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.wiggle]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.wiggle-generate]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-
-[[publisher.wiggle-macro]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.winapi-util]]
 version = "0.1.11"
@@ -901,11 +735,6 @@ when = "2025-09-07"
 user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
-
-[[publisher.winch-codegen]]
-version = "42.0.1"
-when = "2026-02-25"
-trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.windows-core]]
 version = "0.62.2"
@@ -1186,8 +1015,8 @@ when = "2026-01-12"
 trusted-publisher = "github:bytecodealliance/wit-bindgen"
 
 [[publisher.wit-bindgen]]
-version = "0.53.1"
-when = "2026-02-13"
+version = "0.54.0"
+when = "2026-03-16"
 trusted-publisher = "github:bytecodealliance/wit-bindgen"
 
 [[publisher.wit-bindgen-core]]
@@ -1196,8 +1025,8 @@ when = "2026-01-12"
 trusted-publisher = "github:bytecodealliance/wit-bindgen"
 
 [[publisher.wit-bindgen-core]]
-version = "0.53.1"
-when = "2026-02-13"
+version = "0.54.0"
+when = "2026-03-16"
 trusted-publisher = "github:bytecodealliance/wit-bindgen"
 
 [[publisher.wit-bindgen-rust]]
@@ -1206,8 +1035,8 @@ when = "2026-01-12"
 trusted-publisher = "github:bytecodealliance/wit-bindgen"
 
 [[publisher.wit-bindgen-rust]]
-version = "0.53.1"
-when = "2026-02-13"
+version = "0.54.0"
+when = "2026-03-16"
 trusted-publisher = "github:bytecodealliance/wit-bindgen"
 
 [[publisher.wit-bindgen-rust-macro]]
@@ -1216,8 +1045,8 @@ when = "2026-01-12"
 trusted-publisher = "github:bytecodealliance/wit-bindgen"
 
 [[publisher.wit-bindgen-rust-macro]]
-version = "0.53.1"
-when = "2026-02-13"
+version = "0.54.0"
+when = "2026-03-16"
 trusted-publisher = "github:bytecodealliance/wit-bindgen"
 
 [[publisher.wit-component]]
@@ -1240,6 +1069,11 @@ user-login = "wasmtime-publish"
 [[publisher.wit-parser]]
 version = "0.245.1"
 when = "2026-02-12"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+
+[[publisher.wit-parser]]
+version = "0.246.1"
+when = "2026-03-31"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.witx]]
@@ -1263,126 +1097,6 @@ criteria = "safe-to-deploy"
 user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2019-03-16"
 end = "2026-08-21"
-
-[[audits.bytecode-alliance.wildcard-audits.cranelift-assembler-x64]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.cranelift-assembler-x64-meta]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.cranelift-bforest]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.cranelift-bitset]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.cranelift-codegen]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.cranelift-codegen-meta]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.cranelift-codegen-shared]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.cranelift-control]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.cranelift-entity]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.cranelift-frontend]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.cranelift-isle]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.cranelift-native]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.cranelift-srcgen]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.pulley-interpreter]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.pulley-macros]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
 
 [[audits.bytecode-alliance.wildcard-audits.regalloc2]]
 who = "Chris Fallin <chris@cfallin.org>"
@@ -1480,174 +1194,6 @@ start = "2025-08-14"
 end = "2027-01-08"
 notes = "The Bytecode Alliance is the author of this crate"
 
-[[audits.bytecode-alliance.wildcard-audits.wasmtime]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wasmtime-environ]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wasmtime-internal-component-macro]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wasmtime-internal-component-util]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wasmtime-internal-core]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wasmtime-internal-cranelift]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wasmtime-internal-fiber]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wasmtime-internal-jit-debug]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wasmtime-internal-jit-icache-coherence]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wasmtime-internal-unwinder]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wasmtime-internal-versioned-export-macros]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wasmtime-internal-winch]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wasmtime-internal-wit-bindgen]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wasmtime-wasi]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wasmtime-wasi-config]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wasmtime-wasi-http]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wasmtime-wasi-io]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wiggle]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wiggle-generate]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.wiggle-macro]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.wildcard-audits.winch-codegen]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-trusted-publisher = "github:bytecodealliance/wasmtime"
-start = "2026-01-07"
-end = "2027-01-08"
-notes = "The Bytecode Alliance is the author of this crate"
-
 [[audits.bytecode-alliance.wildcard-audits.wit-bindgen]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -1719,12 +1265,6 @@ trusted-publisher = "github:bytecodealliance/wasm-tools"
 start = "2025-08-14"
 end = "2027-01-08"
 notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.bytecode-alliance.audits.addr2line]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "0.25.1 -> 0.26.0"
-notes = "Nothing out of the ordinary for this update, all DWARF all the time."
 
 [[audits.bytecode-alliance.audits.allocator-api2]]
 who = "Chris Fallin <chris@cfallin.org>"
@@ -1947,11 +1487,6 @@ This crate is a single-file crate that does what it says on the tin. There are
 a few `unsafe` blocks related to utf-8 validation which are locally verifiable
 as correct and otherwise this crate is good to go.
 """
-
-[[audits.bytecode-alliance.audits.pin-utils]]
-who = "Pat Hickey <phickey@fastly.com>"
-criteria = "safe-to-deploy"
-version = "0.1.0"
 
 [[audits.bytecode-alliance.audits.pkg-config]]
 who = "Pat Hickey <phickey@fastly.com>"
@@ -2518,83 +2053,6 @@ criteria = "safe-to-deploy"
 version = "1.0.3"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
-[[audits.google.audits.icu_collections]]
-who = "Manish Goregaokar <manishearth@google.com>"
-criteria = "safe-to-deploy"
-version = "2.0.0-beta1"
-notes = """
-Two instances of unsafe :
- - Non-safety related unsafe API that imposes additional invariants
- - `from_utf8` for known-UTF8 integer
-
-Comments added/improved in https://github.com/unicode-org/icu4x/pull/6056.
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.icu_collections]]
-who = "Manish Goregaokar <manishearth@google.com>"
-criteria = "safe-to-deploy"
-delta = "2.0.0-beta1 -> 2.0.0-beta2"
-notes = "from_utf8 unsafe removed. no new unsafe added"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.icu_locale_core]]
-who = "Manish Goregaokar <manishearth@google.com>"
-criteria = "safe-to-deploy"
-version = "2.0.0-beta2"
-notes = """
-All unsafe code commented (and improved from prior version):
-  - A checklisted ULE impl
-  - from-utf8 code on known-ASCII
-  - Some unchecked indexing around maintained invariants
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.icu_normalizer]]
-who = "Manish Goregaokar <manishearth@google.com>"
-criteria = "safe-to-deploy"
-version = "2.0.0-beta2"
-notes = """
-All unsafe is unchecked `char` and `str` conversion, mostly well-commented.
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.icu_normalizer_data]]
-who = "Manish Goregaokar <manishearth@google.com>"
-criteria = "safe-to-deploy"
-version = "2.0.0-beta1"
-notes = "Contains codegenned unsafe only, using safe Bake impls from zerovec/zerotrie"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.icu_normalizer_data]]
-who = "Manish Goregaokar <manishearth@google.com>"
-criteria = "safe-to-deploy"
-delta = "2.0.0-beta1 -> 2.0.0-beta2"
-notes = "Contains codegenned unsafe only, using safe Bake impls from zerovec/zerotrie"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.icu_provider]]
-who = "Manish Goregaokar <manishearth@google.com>"
-criteria = "safe-to-deploy"
-version = "2.0.0-beta1"
-notes = """
-All unsafe code commented:
-  - Minor unsafe transmutes between types which are identical but not type-system-provably so.
-  - One unsafe EqULE impl
-  - Some repr(transparent) transmutes
-  - A from_utf8_unchecked for an ascii-validated string
-
-Comment improvements can be found in https://github.com/unicode-org/icu4x/pull/6056
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.icu_provider]]
-who = "Manish Goregaokar <manishearth@google.com>"
-criteria = "safe-to-deploy"
-delta = "2.0.0-beta1 -> 2.0.0-beta2"
-notes = "from_utf8_unchecked unsafe remove, all other unsafe not meaningfully changed"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
 [[audits.google.audits.lazy_static]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
@@ -2614,20 +2072,6 @@ who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
 delta = "1.4.0 -> 1.5.0"
 notes = "Unsafe review notes: https://crrev.com/c/5650836"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.litemap]]
-who = "Manish Goregaokar <manishearth@google.com>"
-criteria = "safe-to-deploy"
-version = "0.7.4"
-notes = "Contains no unsafe"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.litemap]]
-who = "Daniel Cheng <dcheng@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "0.7.4 -> 0.7.5"
-notes = "Delta implements the entry API but doesn't add or change any unsafe code."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.log]]
@@ -2976,48 +2420,6 @@ who = "Daniel Cheng <dcheng@chromium.org>"
 criteria = "safe-to-deploy"
 delta = "0.6.0 -> 0.6.1"
 notes = "Minor comment/documentation updates and switch to a non-panicking alternative to split_at()."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.yoke-derive]]
-who = "Manish Goregaokar <manishearth@google.com>"
-criteria = "safe-to-deploy"
-version = "0.7.5"
-notes = "Custom derive implementing the `Yokeable` trait. Generally generates simple code that asserts covariance."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.yoke-derive]]
-who = "Daniel Cheng <dcheng@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "0.7.5 -> 0.8.0"
-notes = "No code changes: only incrementing the version."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.zerofrom]]
-who = "Manish Goregaokar <manishearth@google.com>"
-criteria = "safe-to-deploy"
-version = "0.1.5"
-notes = "Contains no unsafe"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.zerofrom]]
-who = "Daniel Cheng <dcheng@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "0.1.5 -> 0.1.6"
-notes = "Only minor cfg tweaks."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.zerofrom-derive]]
-who = "Manish Goregaokar <manishearth@google.com>"
-criteria = "safe-to-deploy"
-version = "0.1.5"
-notes = "Contains no unsafe"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.zerofrom-derive]]
-who = "Daniel Cheng <dcheng@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "0.1.5 -> 0.1.6"
-notes = "Only a minor clippy adjustment."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.isrg.audits.block-buffer]]
@@ -3458,67 +2860,6 @@ criteria = "safe-to-deploy"
 version = "0.4.3"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.icu_collections]]
-who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
-criteria = "safe-to-deploy"
-delta = "2.0.0-beta2 -> 2.0.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.icu_collections]]
-who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
-criteria = "safe-to-deploy"
-delta = "2.0.0 -> 2.1.1"
-notes = "Adding methods have unsafe code for faster, but these have the commnet why this is safe."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.icu_locale_core]]
-who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
-criteria = "safe-to-deploy"
-delta = "2.0.0-beta2 -> 2.0.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.icu_locale_core]]
-who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
-criteria = "safe-to-deploy"
-delta = "2.0.0 -> 2.1.1"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.icu_normalizer]]
-who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
-criteria = "safe-to-deploy"
-delta = "2.0.0-beta2 -> 2.0.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.icu_normalizer]]
-who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
-criteria = "safe-to-deploy"
-delta = "2.0.0 -> 2.1.1"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.icu_normalizer_data]]
-who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
-criteria = "safe-to-deploy"
-delta = "2.0.0-beta2 -> 2.0.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.icu_normalizer_data]]
-who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
-criteria = "safe-to-deploy"
-delta = "2.0.0 -> 2.1.1"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.icu_provider]]
-who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
-criteria = "safe-to-deploy"
-delta = "2.0.0-beta2 -> 2.0.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.icu_provider]]
-who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
-criteria = "safe-to-deploy"
-delta = "2.0.0 -> 2.1.1"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.idna]]
 who = "Valentin Gosu <valentin.gosu@gmail.com>"
 criteria = "safe-to-deploy"
@@ -3547,12 +2888,6 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.10.3 -> 0.10.5"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.litemap]]
-who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
-criteria = "safe-to-deploy"
-delta = "0.7.5 -> 0.8.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.log]]
@@ -3662,13 +2997,6 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 version = "1.1.0"
 notes = "Straightforward crate with no unsafe code, does what it says on the tin."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.rustc-hash]]
-who = "Ben Dean-Kawamura <bdk@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "1.1.0 -> 2.1.1"
-notes = "Simple hashing crate, no unsafe code."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.serde]]
@@ -3827,30 +3155,6 @@ for deleting data. This is expected and documented behavior.
 """
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.zerovec-derive]]
-who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
-criteria = "safe-to-deploy"
-version = "0.10.1"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.zerovec-derive]]
-who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
-criteria = "safe-to-deploy"
-delta = "0.10.1 -> 0.10.2"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.zerovec-derive]]
-who = "Max Inden <mail@max-inden.de>"
-criteria = "safe-to-deploy"
-delta = "0.10.2 -> 0.10.3"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.zerovec-derive]]
-who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
-criteria = "safe-to-deploy"
-delta = "0.10.3 -> 0.11.1"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
 [[audits.zcash.audits.autocfg]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
@@ -3922,12 +3226,6 @@ who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "1.0.0 -> 1.0.1"
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
-
-[[audits.zcash.audits.litemap]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.8.0 -> 0.8.1"
-aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
 
 [[audits.zcash.audits.num_cpus]]
 who = "Jack Grigg <jack@electriccoin.co>"
@@ -4012,16 +3310,6 @@ Migrates to `try-lock 0.2.4` to replace some unsafe APIs that were not marked
 """
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
-[[audits.zcash.audits.yoke-derive]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.8.0 -> 0.8.1"
-notes = """
-Changes to generated `unsafe` code are to silence the `clippy::mem_forget` lint;
-no actual code changes.
-"""
-aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
-
 [[audits.zcash.audits.zeroize]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
@@ -4030,11 +3318,4 @@ notes = """
 Changes to `unsafe` code are to alter how `core::mem::size_of` is named; no actual changes
 to the `unsafe` logic.
 """
-aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
-
-[[audits.zcash.audits.zerovec-derive]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "0.11.1 -> 0.11.2"
-notes = "Only changes to generated code are clippy lints."
 aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"


### PR DESCRIPTION
Upgrade to wasmtime 43/44, fixed issues with the upgrade, and performance improvements to wasi_http's default_impl

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk due to a major Wasmtime/wasip3/wit-bindgen upgrade (including a temporary git patch override) and non-trivial changes to `wasi-http` request/response handling that affect streaming and resource lifetimes.
> 
> **Overview**
> Upgrades the workspace to `wasmtime`/`wasmtime-wasi*` `44.0.0`, `wasip3` `0.5.0`, and `wit-bindgen` `0.54.0`, including a temporary `[patch.crates-io]` override to pull Wasmtime from the `bytecodealliance/wasmtime` `main` branch and corresponding `Cargo.lock` refresh.
> 
> Updates `wasi-http` host code for the new APIs: `HttpDefault` now owns a reusable `reqwest::Client` (with configurable `HTTP_CONNECT_TIMEOUT_SECS`) and only builds one-off clients when a client certificate is provided, and the `omnia_wasi_view!` macro uses the new `as_view` pattern.
> 
> Fixes/adjusts HTTP proxying behavior in `wasi-http` server handling by improving guest error propagation and keeping `wasmtime::Store::run_concurrent` alive until Hyper finishes consuming the streamed response body (via a body wrapper), avoiding premature teardown of WASI pipe resources.
> 
> Includes small WASM SDK compatibility tweaks (blobstore API signature updates and more informative debug formatting in an error path) and updates supply-chain/cargo-deny configuration to allow the new git source and refreshed exemptions/audits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e6dfa4d97a383a91fa07c5f8e60b9f6455925dd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->