### PR TITLE
Removed HOST header altogether in favor of `reqwest` setting it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
  "indexmap",
  "js-sys",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.3",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -676,7 +676,7 @@ dependencies = [
 [[package]]
 name = "cranelift-assembler-x64"
 version = "0.131.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
@@ -684,7 +684,7 @@ dependencies = [
 [[package]]
 name = "cranelift-assembler-x64-meta"
 version = "0.131.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "cranelift-srcgen",
 ]
@@ -692,7 +692,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.131.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bitset"
 version = "0.131.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "serde",
  "serde_derive",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.131.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.131.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -750,12 +750,12 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.131.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 
 [[package]]
 name = "cranelift-control"
 version = "0.131.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "arbitrary",
 ]
@@ -763,7 +763,7 @@ dependencies = [
 [[package]]
 name = "cranelift-entity"
 version = "0.131.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.131.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -785,12 +785,12 @@ dependencies = [
 [[package]]
 name = "cranelift-isle"
 version = "0.131.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 
 [[package]]
 name = "cranelift-native"
 version = "0.131.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "cranelift-srcgen"
 version = "0.131.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 
 [[package]]
 name = "crc32fast"
@@ -1346,6 +1346,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "hashlink"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,15 +1447,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1635,12 +1640,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1774,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1843,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.25"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2118,7 +2123,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "rand 0.10.0",
+ "rand 0.10.1",
  "tower",
  "tracing",
  "tracing-opentelemetry",
@@ -2478,7 +2483,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.3",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -2541,9 +2546,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polodb-librocksdb-sys"
@@ -2647,7 +2652,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -2700,7 +2705,7 @@ dependencies = [
 [[package]]
 name = "pulley-interpreter"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -2711,7 +2716,7 @@ dependencies = [
 [[package]]
 name = "pulley-macros"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2748,7 +2753,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -2823,9 +2828,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2833,9 +2838,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -3179,9 +3184,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3244,9 +3249,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3325,9 +3330,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -3710,9 +3715,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -3725,9 +3730,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3962,7 +3967,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "sha1",
  "thiserror 2.0.18",
 ]
@@ -4111,9 +4116,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4124,9 +4129,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4134,9 +4139,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4144,9 +4149,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4157,9 +4162,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -4186,12 +4191,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.246.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e1929aad146499e47362c876fcbcbb0363f730951d93438f511178626e999a8"
+checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.246.1",
+ "wasmparser 0.246.2",
 ]
 
 [[package]]
@@ -4244,9 +4249,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.246.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d991c35d79bf8336dc1cd632ed4aacf0dc5fac4bc466c670625b037b972bb9c"
+checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
 dependencies = [
  "bitflags",
  "hashbrown 0.16.1",
@@ -4257,19 +4262,19 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.246.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267a5e255a8f9ac8dd403fe6dbfc45f17594b1b7be211c2494c95bfa086d3906"
+checksum = "6e41f7493ba994b8a779430a4c25ff550fd5a40d291693af43a6ef48688f00e3"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.246.1",
+ "wasmparser 0.246.2",
 ]
 
 [[package]]
 name = "wasmtime"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -4295,7 +4300,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.246.1",
+ "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-component-macro",
  "wasmtime-internal-component-util",
@@ -4313,7 +4318,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-environ"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -4333,8 +4338,8 @@ dependencies = [
  "sha2",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.246.1",
- "wasmparser 0.246.1",
+ "wasm-encoder 0.246.2",
+ "wasmparser 0.246.2",
  "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
@@ -4343,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-component-macro"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4351,18 +4356,18 @@ dependencies = [
  "syn",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.246.1",
+ "wit-parser 0.246.2",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 
 [[package]]
 name = "wasmtime-internal-core"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "anyhow",
  "hashbrown 0.16.1",
@@ -4373,7 +4378,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-cranelift"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4389,7 +4394,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.246.1",
+ "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -4399,7 +4404,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-fiber"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "cc",
  "cfg-if",
@@ -4413,7 +4418,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-jit-debug"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros",
@@ -4422,7 +4427,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4433,7 +4438,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-unwinder"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4445,7 +4450,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4455,14 +4460,14 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-winch"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "cranelift-codegen",
  "gimli",
  "log",
  "object",
  "target-lexicon",
- "wasmparser 0.246.1",
+ "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -4471,19 +4476,19 @@ dependencies = [
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "anyhow",
  "bitflags",
  "heck",
  "indexmap",
- "wit-parser 0.246.1",
+ "wit-parser 0.246.2",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -4512,7 +4517,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-config"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "wasmtime",
 ]
@@ -4520,7 +4525,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-http"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4543,7 +4548,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-wasi-io"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4563,9 +4568,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4611,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "wiggle"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "bitflags",
  "thiserror 2.0.18",
@@ -4624,7 +4629,7 @@ dependencies = [
 [[package]]
 name = "wiggle-generate"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4637,7 +4642,7 @@ dependencies = [
 [[package]]
 name = "wiggle-macro"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4679,7 +4684,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "winch-codegen"
 version = "44.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?branch=main#763622c304a5ccb38cd7530d2dcda5bd0fa8b0d0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-44.0.0#39e910be5d584f810b71ebe321ee53d59235ade4"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",
@@ -4688,7 +4693,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.246.1",
+ "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
@@ -5209,9 +5214,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.246.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc133164d0fa0a990756d5cdb1a4c24e1f638643e1f3e085d0e51111968e8536"
+checksum = "fd979042b5ff288607ccf3b314145435453f20fc67173195f91062d2289b204d"
 dependencies = [
  "anyhow",
  "hashbrown 0.16.1",
@@ -5223,7 +5228,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.246.1",
+ "wasmparser 0.246.2",
 ]
 
 [[package]]
@@ -5240,9 +5245,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,8 +128,8 @@ strip = true
 
 # TODO: remove once wasmtime 44 is published on crates.io
 [patch.crates-io]
-wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", branch = "main" }
-wasmtime-wasi = { git = "https://github.com/bytecodealliance/wasmtime", branch = "main" }
-wasmtime-wasi-config = { git = "https://github.com/bytecodealliance/wasmtime", branch = "main" }
-wasmtime-wasi-http = { git = "https://github.com/bytecodealliance/wasmtime", branch = "main" }
-wasmtime-wasi-io = { git = "https://github.com/bytecodealliance/wasmtime", branch = "main" }
+wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", branch = "release-44.0.0" }
+wasmtime-wasi = { git = "https://github.com/bytecodealliance/wasmtime", branch = "release-44.0.0" }
+wasmtime-wasi-config = { git = "https://github.com/bytecodealliance/wasmtime", branch = "release-44.0.0" }
+wasmtime-wasi-http = { git = "https://github.com/bytecodealliance/wasmtime", branch = "release-44.0.0" }
+wasmtime-wasi-io = { git = "https://github.com/bytecodealliance/wasmtime", branch = "release-44.0.0" }

--- a/crates/wasi-http/src/host/default_impl.rs
+++ b/crates/wasi-http/src/host/default_impl.rs
@@ -115,14 +115,8 @@ impl p3::WasiHttpHooks for HttpHooks {
         Box::new(async move {
             let (mut parts, body) = request.into_parts();
 
-            // dedupe "Host" headers (keep the one added by wasmtime/wasip3?)
-            let values = parts.headers.get_all(HOST).iter().cloned().collect::<Vec<_>>();
-            if values.len() > 1 {
-                parts.headers.remove(HOST);
-                for v in values.into_iter().skip(1) {
-                    parts.headers.append(HOST, v);
-                }
-            }
+            // remove "Host" headers (`reqwest` adds its own)
+            parts.headers.remove(HOST);
 
             // use a one-off client when a client certificate is required, otherwise
             // reuse the shared client for connection pooling
@@ -239,7 +233,7 @@ mod tests {
         assert_eq!(requests.len(), 1);
 
         assert_eq!(requests[0].headers.get_all(HOST).iter().count(), 1);
-        assert_eq!(requests[0].headers.get(HOST).unwrap().to_str().unwrap(), "localhost-2");
+        assert!(requests[0].headers.get(HOST).unwrap().to_str().unwrap().starts_with("127.0.0.1:"));
     }
 
     #[tokio::test]

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,10 @@ ignore = [
   # Transitive via wasmtime-wasi-http -> rustls 0.22; fix requires
   # wasmtime to bump to rustls 0.23+ (rustls-webpki 0.103.10+).
   "RUSTSEC-2026-0049",
+  # rand 0.8.5 unsoundness with custom logger + thread_rng reseeding.
+  # Transitive via wasmtime-wasi (cap-rand) and oauth2; no 0.8.x patch
+  # available — fix requires upstream to bump to rand 0.9.3+.
+  "RUSTSEC-2026-0097",
 ]
 
 [licenses]
@@ -51,4 +55,3 @@ wildcards = "allow"
 duplicates = "deny"
 include-path-dependencies = true
 unused = "warn"
-

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -87,7 +87,7 @@ version = "0.1.13+1.0.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.cc]]
-version = "1.2.58"
+version = "1.2.60"
 criteria = "safe-to-deploy"
 
 [[exemptions.cesu8]]
@@ -275,7 +275,7 @@ version = "0.3.3"
 criteria = "safe-to-run"
 
 [[exemptions.hyper-rustls]]
-version = "0.27.7"
+version = "0.27.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.hyper-timeout]]
@@ -355,7 +355,7 @@ version = "0.1.34"
 criteria = "safe-to-deploy"
 
 [[exemptions.js-sys]]
-version = "0.3.94"
+version = "0.3.95"
 criteria = "safe-to-deploy"
 
 [[exemptions.lazycell]]
@@ -371,7 +371,7 @@ version = "0.37.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.libz-sys]]
-version = "1.1.25"
+version = "1.1.28"
 criteria = "safe-to-deploy"
 
 [[exemptions.litemap]]
@@ -458,6 +458,10 @@ criteria = "safe-to-deploy"
 version = "0.2.17"
 criteria = "safe-to-deploy"
 
+[[exemptions.pkg-config]]
+version = "0.3.33"
+criteria = "safe-to-deploy"
+
 [[exemptions.polodb-librocksdb-sys]]
 version = "9.0.0-alpha.1"
 criteria = "safe-to-deploy"
@@ -518,6 +522,14 @@ criteria = "safe-to-deploy"
 version = "0.1.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.rand]]
+version = "0.9.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.rand_xorshift]]
 version = "0.4.0"
 criteria = "safe-to-deploy"
@@ -555,7 +567,7 @@ version = "2.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls]]
-version = "0.23.37"
+version = "0.23.38"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls-native-certs]]
@@ -575,7 +587,7 @@ version = "0.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls-webpki]]
-version = "0.103.10"
+version = "0.103.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.same-file]]
@@ -719,27 +731,27 @@ version = "2.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen]]
-version = "0.2.117"
+version = "0.2.118"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-futures]]
-version = "0.4.67"
+version = "0.4.68"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro]]
-version = "0.2.117"
+version = "0.2.118"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro-support]]
-version = "0.2.117"
+version = "0.2.118"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-shared]]
-version = "0.2.117"
+version = "0.2.118"
 criteria = "safe-to-deploy"
 
 [[exemptions.web-sys]]
-version = "0.3.94"
+version = "0.3.95"
 criteria = "safe-to-deploy"
 
 [[exemptions.web-time]]
@@ -773,6 +785,10 @@ criteria = "safe-to-deploy"
 [[exemptions.wiremock]]
 version = "0.6.5"
 criteria = "safe-to-run"
+
+[[exemptions.writeable]]
+version = "0.6.3"
+criteria = "safe-to-deploy"
 
 [[exemptions.wyz]]
 version = "0.5.1"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -222,6 +222,12 @@ when = "2025-11-20"
 user-id = 55123
 user-login = "rust-lang-owner"
 
+[[publisher.hashbrown]]
+version = "0.17.0"
+when = "2026-04-09"
+user-id = 55123
+user-login = "rust-lang-owner"
+
 [[publisher.http]]
 version = "1.4.0"
 when = "2025-11-24"
@@ -265,8 +271,8 @@ user-login = "Manishearth"
 user-name = "Manish Goregaokar"
 
 [[publisher.indexmap]]
-version = "2.13.0"
-when = "2026-01-07"
+version = "2.14.0"
+when = "2026-04-09"
 user-id = 539
 user-login = "cuviper"
 user-name = "Josh Stone"
@@ -486,8 +492,8 @@ user-login = "Amanieu"
 user-name = "Amanieu d'Antras"
 
 [[publisher.semver]]
-version = "1.0.27"
-when = "2025-09-14"
+version = "1.0.28"
+when = "2026-04-04"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -591,15 +597,15 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.tokio]]
-version = "1.50.0"
-when = "2026-03-03"
+version = "1.51.1"
+when = "2026-04-08"
 user-id = 6741
 user-login = "Darksonn"
 user-name = "Alice Ryhl"
 
 [[publisher.tokio-macros]]
-version = "2.6.1"
-when = "2026-03-02"
+version = "2.7.0"
+when = "2026-04-03"
 user-id = 6741
 user-login = "Darksonn"
 user-name = "Alice Ryhl"
@@ -693,8 +699,8 @@ when = "2026-02-12"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasm-encoder]]
-version = "0.246.1"
-when = "2026-03-31"
+version = "0.246.2"
+when = "2026-04-03"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasm-metadata]]
@@ -720,13 +726,13 @@ when = "2026-02-12"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmparser]]
-version = "0.246.1"
-when = "2026-03-31"
+version = "0.246.2"
+when = "2026-04-03"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmprinter]]
-version = "0.246.1"
-when = "2026-03-31"
+version = "0.246.2"
+when = "2026-04-03"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.winapi-util]]
@@ -1072,8 +1078,8 @@ when = "2026-02-12"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wit-parser]]
-version = "0.246.1"
-when = "2026-03-31"
+version = "0.246.2"
+when = "2026-04-03"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.witx]]
@@ -1487,26 +1493,6 @@ This crate is a single-file crate that does what it says on the tin. There are
 a few `unsafe` blocks related to utf-8 validation which are locally verifiable
 as correct and otherwise this crate is good to go.
 """
-
-[[audits.bytecode-alliance.audits.pkg-config]]
-who = "Pat Hickey <phickey@fastly.com>"
-criteria = "safe-to-deploy"
-version = "0.3.25"
-notes = "This crate shells out to the pkg-config executable, but it appears to sanitize inputs reasonably."
-
-[[audits.bytecode-alliance.audits.pkg-config]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "0.3.26 -> 0.3.29"
-notes = """
-No `unsafe` additions or anything outside of the purview of the crate in this
-change.
-"""
-
-[[audits.bytecode-alliance.audits.pkg-config]]
-who = "Chris Fallin <chris@cfallin.org>"
-criteria = "safe-to-deploy"
-delta = "0.3.29 -> 0.3.32"
 
 [[audits.bytecode-alliance.audits.postcard]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -2408,20 +2394,6 @@ version = "0.13.1"
 notes = "Exposes unsafe codegen APIs but does not itself contain unsafe"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.writeable]]
-who = "Manish Goregaokar <manishearth@google.com>"
-criteria = "safe-to-deploy"
-version = "0.6.0"
-notes = "Contains three lines of unsafe, thoroughly commented: one is for from-UTF8 on ASCII, the other two are for from-UTF8 on a datastructure that keeps track of a buffer with partial UTF8 validation. Relatively straigtforward."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.writeable]]
-who = "Daniel Cheng <dcheng@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "0.6.0 -> 0.6.1"
-notes = "Minor comment/documentation updates and switch to a non-panicking alternative to split_at()."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
 [[audits.isrg.audits.block-buffer]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
@@ -2451,21 +2423,6 @@ version = "0.10.0"
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.2.17 -> 0.3.0"
-
-[[audits.isrg.audits.rand]]
-who = "David Cook <dcook@divviup.org>"
-criteria = "safe-to-deploy"
-delta = "0.8.5 -> 0.9.1"
-
-[[audits.isrg.audits.rand]]
-who = "Tim Geoghegan <timg@divviup.org>"
-criteria = "safe-to-deploy"
-delta = "0.9.1 -> 0.9.2"
-
-[[audits.isrg.audits.rand]]
-who = "David Cook <dcook@divviup.org>"
-criteria = "safe-to-deploy"
-delta = "0.9.2 -> 0.10.0"
 
 [[audits.isrg.audits.rand_chacha]]
 who = "David Cook <dcook@divviup.org>"
@@ -2914,12 +2871,6 @@ criteria = "safe-to-deploy"
 delta = "2.3.1 -> 2.3.2"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.pkg-config]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.3.25 -> 0.3.26"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.powerfmt]]
 who = "Alex Franchuk <afranchuk@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -3138,12 +3089,6 @@ who = "Nika Layzell <nika@thelayzells.com>"
 criteria = "safe-to-deploy"
 delta = "0.2.1 -> 0.2.2"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.writeable]]
-who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
-criteria = "safe-to-deploy"
-delta = "0.6.1 -> 0.6.2"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.zeroize]]
 who = "Benjamin Beurdouche <beurdouche@mozilla.com>"


### PR DESCRIPTION
Removed HOST header altogether in favor of `reqwest` setting it. Also pegged `wasmtime` to the `release-44.0.0` branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches outbound HTTP request header handling and updates/pins several core dependencies (including `wasmtime`, `tokio`, and `rustls`), which could affect request routing/compatibility and runtime behavior.
> 
> **Overview**
> Outbound `wasi:http` requests now **strip all `Host` headers** before sending, relying on `reqwest` to set the correct `Host` value; the existing test is adjusted to assert the received host matches `reqwest`'s resolved address format.
> 
> Dependency management is updated by switching the `[patch.crates-io]` override for `wasmtime*` from the `main` branch to `release-44.0.0`, alongside lockfile bumps for several transitive crates (e.g., `tokio`, `rustls`, `rand`, `indexmap/hashbrown`) and corresponding `cargo-deny`/`cargo-vet` config updates (including a new ignored `rand` advisory and updated exemptions/publisher entries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fd0c50b56ae006909451277ad95b4e127f6618b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->