### PR TITLE
Minor orm deduplications

### DIFF
--- a/crates/orm/src/delete.rs
+++ b/crates/orm/src/delete.rs
@@ -3,9 +3,9 @@ use std::marker::PhantomData;
 use anyhow::Result;
 use sea_query::{Alias, SimpleExpr};
 
-use crate::entity::{Entity, values_to_wasi_datatypes};
+use crate::entity::Entity;
 use crate::filter::Filter;
-use crate::query::{Query, QueryBuilder};
+use crate::query::{Query, finish};
 
 /// Builder for constructing DELETE queries.
 pub struct DeleteBuilder<M: Entity> {
@@ -62,16 +62,6 @@ impl<M: Entity> DeleteBuilder<M> {
             statement.returning_col(Alias::new(column));
         }
 
-        let (sql, values) = statement.build(QueryBuilder::default());
-        let params = values_to_wasi_datatypes(values)?;
-
-        tracing::debug!(
-            table = M::TABLE,
-            sql = %sql,
-            param_count = params.len(),
-            "DeleteBuilder generated SQL"
-        );
-
-        Ok(Query { sql, params })
+        finish(&statement, M::TABLE, "delete")
     }
 }

--- a/crates/orm/src/entity.rs
+++ b/crates/orm/src/entity.rs
@@ -204,76 +204,48 @@ fn value_to_wasi_datatype(value: Value) -> Result<DataType> {
     Ok(data_type)
 }
 
-// Inbound conversion
-impl FetchValue for bool {
-    fn fetch(row: &Row, col: &str) -> anyhow::Result<Self> {
-        as_bool(row_field(row, col)?)
-    }
+// Inbound conversion: generate FetchValue impls for primitive types whose DataType variant
+// is a direct `Option<T>` carrying the value (no parsing required).
+macro_rules! fetch {
+    ($($ty:ty => $variant:ident),* $(,)?) => {$(
+        impl FetchValue for $ty {
+            fn fetch(row: &Row, col: &str) -> anyhow::Result<Self> {
+                match row_field(row, col)? {
+                    DataType::$variant(Some(v)) => Ok(v.clone()),
+                    _ => bail!(concat!("expected ", stringify!($variant), " data type")),
+                }
+            }
+        }
+    )*};
 }
 
-impl FetchValue for i32 {
-    fn fetch(row: &Row, col: &str) -> anyhow::Result<Self> {
-        as_i32(row_field(row, col)?)
-    }
-}
-
-impl FetchValue for i64 {
-    fn fetch(row: &Row, col: &str) -> anyhow::Result<Self> {
-        as_i64(row_field(row, col)?)
-    }
-}
-
-impl FetchValue for u32 {
-    fn fetch(row: &Row, col: &str) -> anyhow::Result<Self> {
-        as_u32(row_field(row, col)?)
-    }
-}
-
-impl FetchValue for u64 {
-    fn fetch(row: &Row, col: &str) -> anyhow::Result<Self> {
-        as_u64(row_field(row, col)?)
-    }
-}
-
-impl FetchValue for f32 {
-    fn fetch(row: &Row, col: &str) -> anyhow::Result<Self> {
-        as_f32(row_field(row, col)?)
-    }
-}
-
-impl FetchValue for f64 {
-    fn fetch(row: &Row, col: &str) -> anyhow::Result<Self> {
-        as_f64(row_field(row, col)?)
-    }
-}
-
-impl FetchValue for String {
-    fn fetch(row: &Row, col: &str) -> anyhow::Result<Self> {
-        as_string(row_field(row, col)?)
-    }
-}
-
-impl FetchValue for Vec<u8> {
-    fn fetch(row: &Row, col: &str) -> anyhow::Result<Self> {
-        as_binary(row_field(row, col)?)
-    }
+fetch! {
+    bool    => Boolean,
+    i32     => Int32,
+    i64     => Int64,
+    u32     => Uint32,
+    u64     => Uint64,
+    f32     => Float,
+    f64     => Double,
+    String  => Str,
+    Vec<u8> => Binary,
 }
 
 impl FetchValue for DateTime<Utc> {
     fn fetch(row: &Row, col: &str) -> anyhow::Result<Self> {
-        as_timestamp(row_field(row, col)?)
+        parse_timestamp(row_field(row, col)?)
     }
 }
 
 impl FetchValue for NaiveDate {
     fn fetch(row: &Row, col: &str) -> anyhow::Result<Self> {
-        as_date(row_field(row, col)?)
+        parse_date(row_field(row, col)?)
     }
 }
 
 impl FetchValue for serde_json::Value {
     fn fetch(row: &Row, col: &str) -> anyhow::Result<Self> {
-        as_json(row_field(row, col)?)
+        parse_json(row_field(row, col)?)
     }
 }
 
@@ -312,70 +284,7 @@ const fn is_null(value: &DataType) -> bool {
     )
 }
 
-fn as_bool(value: &DataType) -> Result<bool> {
-    match value {
-        DataType::Boolean(Some(v)) => Ok(*v),
-        _ => bail!("expected boolean data type"),
-    }
-}
-
-fn as_i32(value: &DataType) -> Result<i32> {
-    match value {
-        DataType::Int32(Some(v)) => Ok(*v),
-        _ => bail!("expected int32 data type"),
-    }
-}
-
-fn as_i64(value: &DataType) -> Result<i64> {
-    match value {
-        DataType::Int64(Some(v)) => Ok(*v),
-        _ => bail!("expected int64 data type"),
-    }
-}
-
-fn as_u32(value: &DataType) -> Result<u32> {
-    match value {
-        DataType::Uint32(Some(v)) => Ok(*v),
-        _ => bail!("expected uint32 data type"),
-    }
-}
-
-fn as_u64(value: &DataType) -> Result<u64> {
-    match value {
-        DataType::Uint64(Some(v)) => Ok(*v),
-        _ => bail!("expected uint64 data type"),
-    }
-}
-
-fn as_f32(value: &DataType) -> Result<f32> {
-    match value {
-        DataType::Float(Some(v)) => Ok(*v),
-        _ => bail!("expected float data type"),
-    }
-}
-
-fn as_f64(value: &DataType) -> Result<f64> {
-    match value {
-        DataType::Double(Some(v)) => Ok(*v),
-        _ => bail!("expected double data type"),
-    }
-}
-
-fn as_string(value: &DataType) -> Result<String> {
-    match value {
-        DataType::Str(Some(raw)) => Ok(raw.clone()),
-        _ => bail!("expected string data type"),
-    }
-}
-
-fn as_binary(value: &DataType) -> Result<Vec<u8>> {
-    match value {
-        DataType::Binary(Some(bytes)) => Ok(bytes.clone()),
-        _ => bail!("expected binary data type"),
-    }
-}
-
-fn as_timestamp(value: &DataType) -> Result<DateTime<Utc>> {
+fn parse_timestamp(value: &DataType) -> Result<DateTime<Utc>> {
     match value {
         DataType::Timestamp(Some(raw)) => {
             if let Ok(parsed) = DateTime::parse_from_rfc3339(raw) {
@@ -394,7 +303,7 @@ fn as_timestamp(value: &DataType) -> Result<DateTime<Utc>> {
     }
 }
 
-fn as_date(value: &DataType) -> Result<NaiveDate> {
+fn parse_date(value: &DataType) -> Result<NaiveDate> {
     match value {
         DataType::Date(Some(raw)) => NaiveDate::parse_from_str(raw, "%Y-%m-%d")
             .map_err(|_e| anyhow!("unsupported date: {raw}; expected \"%Y-%m-%d\" format")),
@@ -402,7 +311,7 @@ fn as_date(value: &DataType) -> Result<NaiveDate> {
     }
 }
 
-fn as_json(value: &DataType) -> Result<serde_json::Value> {
+fn parse_json(value: &DataType) -> Result<serde_json::Value> {
     match value {
         DataType::Str(Some(raw)) => Ok(serde_json::from_str(raw)?),
         DataType::Binary(Some(bytes)) => Ok(serde_json::from_slice(bytes)?),
@@ -556,36 +465,46 @@ mod tests {
     }
 
     #[test]
-    fn as_type_conversion_errors() {
-        // Test that as_* functions properly reject wrong types
+    fn fetch_value_rejects_wrong_types() {
+        use crate::Field;
 
-        // as_bool should reject non-boolean
-        let result = as_bool(&DataType::Int32(Some(1)));
-        result.unwrap_err();
+        fn one_field_row(value: DataType) -> Row {
+            Row {
+                fields: vec![Field {
+                    name: "x".to_string(),
+                    value,
+                }],
+                index: "0".to_string(),
+            }
+        }
 
-        // as_i32 should reject non-int32
-        let result = as_i32(&DataType::Str(Some("not a number".to_string())));
-        result.unwrap_err();
+        // bool should reject non-boolean
+        bool::fetch(&one_field_row(DataType::Int32(Some(1))), "x").unwrap_err();
 
-        // as_i64 should reject non-int64
-        let result = as_i64(&DataType::Boolean(Some(true)));
-        result.unwrap_err();
+        // i32 should reject non-int32
+        i32::fetch(&one_field_row(DataType::Str(Some("not a number".to_string()))), "x")
+            .unwrap_err();
 
-        // as_string should reject non-string
-        let result = as_string(&DataType::Int32(Some(42)));
-        result.unwrap_err();
+        // i64 should reject non-int64
+        i64::fetch(&one_field_row(DataType::Boolean(Some(true))), "x").unwrap_err();
 
-        // as_binary should reject non-binary
-        let result = as_binary(&DataType::Str(Some("not binary".to_string())));
-        result.unwrap_err();
+        // String should reject non-string
+        String::fetch(&one_field_row(DataType::Int32(Some(42))), "x").unwrap_err();
 
-        // as_timestamp should reject invalid date format
-        let result = as_timestamp(&DataType::Timestamp(Some("invalid date".to_string())));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("unsupported timestamp"));
+        // Vec<u8> should reject non-binary
+        <Vec<u8>>::fetch(&one_field_row(DataType::Str(Some("not binary".to_string()))), "x")
+            .unwrap_err();
 
-        // as_json should reject invalid JSON
-        let result = as_json(&DataType::Str(Some("not json".to_string())));
-        result.unwrap_err();
+        // DateTime<Utc> should reject invalid timestamp format
+        let err = DateTime::<Utc>::fetch(
+            &one_field_row(DataType::Timestamp(Some("invalid".into()))),
+            "x",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("unsupported timestamp"));
+
+        // serde_json::Value should reject invalid JSON
+        serde_json::Value::fetch(&one_field_row(DataType::Str(Some("not json".to_string()))), "x")
+            .unwrap_err();
     }
 }

--- a/crates/orm/src/filter.rs
+++ b/crates/orm/src/filter.rs
@@ -2,149 +2,125 @@ use sea_query::{Expr, ExprTrait, SimpleExpr, Value};
 
 use crate::select::table_column;
 
+/// A column reference, optionally qualified with a table name.
+///
+/// When `table` is `None`, the column resolves against the entity's default table
+/// at query-build time. Use [`ColRef::qualified`] to bind a specific table for
+/// joined queries.
+#[derive(Debug, Clone, Copy)]
+pub struct ColRef {
+    /// Optional table qualifier. When `None`, the entity's default table is used at build time.
+    pub table: Option<&'static str>,
+    /// Column name.
+    pub column: &'static str,
+}
+
+impl ColRef {
+    /// Constructs a column reference with no table qualifier (resolved against the entity's
+    /// default table at build time).
+    #[must_use]
+    pub const fn unqualified(column: &'static str) -> Self {
+        Self { table: None, column }
+    }
+
+    /// Constructs an explicitly table-qualified column reference.
+    #[must_use]
+    pub const fn qualified(table: &'static str, column: &'static str) -> Self {
+        Self {
+            table: Some(table),
+            column,
+        }
+    }
+
+    fn resolve(self, default_table: &'static str) -> SimpleExpr {
+        Expr::col(table_column(self.table.unwrap_or(default_table), self.column)).into()
+    }
+}
+
+/// Comparison operators for [`Filter::Compare`] and [`Filter::ColCompare`].
+#[derive(Debug, Clone, Copy)]
+pub enum CmpOp {
+    /// `=`
+    Eq,
+    /// `!=`
+    Ne,
+    /// `>`
+    Gt,
+    /// `>=`
+    Gte,
+    /// `<`
+    Lt,
+    /// `<=`
+    Lte,
+}
+
 /// Filter represents database predicates without exposing ``SeaQuery`` types to guest code.
 ///
 /// Values are stored internally as ``sea_query::Value`` but guest code never imports ``SeaQuery``.
 /// Instead, guests use natural Rust types (i32, String, ``DateTime<Utc>``) which convert via From.
-///
-/// For filters with optional table parameter: None uses the entity's default table,
-/// ``Some("table_name")`` uses the specified table (useful for joins).
 #[derive(Debug, Clone)]
 pub enum Filter {
-    // Using static lifetimes since table and column names are compile time constants
-    /// [table.]column = value
-    Eq(Option<&'static str>, &'static str, Value),
-    /// [table.]column != value
-    Ne(Option<&'static str>, &'static str, Value),
-    /// [table.]column > value
-    Gt(Option<&'static str>, &'static str, Value),
-    /// [table.]column >= value
-    Gte(Option<&'static str>, &'static str, Value),
-    /// [table.]column < value
-    Lt(Option<&'static str>, &'static str, Value),
-    /// [table.]column <= value
-    Lte(Option<&'static str>, &'static str, Value),
-    /// [table.]column IN (values)
-    In(Option<&'static str>, &'static str, Vec<Value>),
-    /// [table.]column NOT IN (values)
-    NotIn(Option<&'static str>, &'static str, Vec<Value>),
-    /// [table.]column IS NULL
-    IsNull(Option<&'static str>, &'static str),
-    /// [table.]column IS NOT NULL
-    IsNotNull(Option<&'static str>, &'static str),
-    /// [table.]column LIKE pattern
-    Like(Option<&'static str>, &'static str, String),
-    /// [table.]column NOT LIKE pattern
-    NotLike(Option<&'static str>, &'static str, String),
-    /// [table.]column BETWEEN low AND high
-    Between(Option<&'static str>, &'static str, Value, Value),
-    /// [table.]column NOT BETWEEN low AND high
-    NotBetween(Option<&'static str>, &'static str, Value, Value),
-    /// [table.]column = ANY(values)
-    Any(Option<&'static str>, &'static str, Vec<Value>),
-    /// Column-to-column comparison: table1.col1 = table2.col2
-    ColEq(&'static str, &'static str, &'static str, &'static str),
-    /// Column-to-column comparison: table1.col1 != table2.col2
-    ColNe(&'static str, &'static str, &'static str, &'static str),
-    /// Column-to-column comparison: table1.col1 > table2.col2
-    ColGt(&'static str, &'static str, &'static str, &'static str),
-    /// Column-to-column comparison: table1.col1 >= table2.col2
-    ColGte(&'static str, &'static str, &'static str, &'static str),
-    /// Column-to-column comparison: table1.col1 < table2.col2
-    ColLt(&'static str, &'static str, &'static str, &'static str),
-    /// Column-to-column comparison: table1.col1 <= table2.col2
-    ColLte(&'static str, &'static str, &'static str, &'static str),
-    /// Logical AND of multiple filters
+    /// `col <op> value`
+    Compare(ColRef, CmpOp, Value),
+    /// `col IN (values)` or `col NOT IN (values)` when negated.
+    In(ColRef, Vec<Value>, bool),
+    /// `col IS NULL` or `col IS NOT NULL` when negated.
+    Null(ColRef, bool),
+    /// `col LIKE pattern` or `col NOT LIKE pattern` when negated.
+    Like(ColRef, String, bool),
+    /// `col BETWEEN low AND high` or `col NOT BETWEEN low AND high` when negated.
+    Between(ColRef, Value, Value, bool),
+    /// Column-to-column comparison, e.g. `table1.col1 <op> table2.col2`.
+    ColCompare(ColRef, CmpOp, ColRef),
+    /// Logical AND of multiple filters.
     And(Vec<Self>),
-    /// Logical OR of multiple filters
+    /// Logical OR of multiple filters.
     Or(Vec<Self>),
-    /// Logical NOT of a filter
+    /// Logical NOT of a filter.
     Not(Box<Self>),
 }
 
-impl Filter {
-    /// Helper to resolve a column reference with optional table qualifier
-    fn resolve_column(
-        tbl: Option<&'static str>, col: &'static str, default_table: &'static str,
-    ) -> SimpleExpr {
-        Expr::col(table_column(tbl.unwrap_or(default_table), col)).into()
+fn apply_cmp(left: SimpleExpr, op: CmpOp, right: SimpleExpr) -> SimpleExpr {
+    match op {
+        CmpOp::Eq => left.eq(right),
+        CmpOp::Ne => left.ne(right),
+        CmpOp::Gt => left.gt(right),
+        CmpOp::Gte => left.gte(right),
+        CmpOp::Lt => left.lt(right),
+        CmpOp::Lte => left.lte(right),
     }
+}
 
-    /// Convert Filter to ``SeaQuery`` ``SimpleExpr`` using the specified table name.
+impl Filter {
+    /// Convert Filter to ``SeaQuery`` ``SimpleExpr`` using the specified default table.
     #[must_use]
     pub fn into_expr(self, default_table: &'static str) -> SimpleExpr {
         match self {
-            Self::Eq(tbl, col, val) => Self::resolve_column(tbl, col, default_table).eq(val),
-            Self::Ne(tbl, col, val) => Self::resolve_column(tbl, col, default_table).ne(val),
-            Self::Gt(tbl, col, val) => Self::resolve_column(tbl, col, default_table).gt(val),
-            Self::Gte(tbl, col, val) => Self::resolve_column(tbl, col, default_table).gte(val),
-            Self::Lt(tbl, col, val) => Self::resolve_column(tbl, col, default_table).lt(val),
-            Self::Lte(tbl, col, val) => Self::resolve_column(tbl, col, default_table).lte(val),
-            Self::In(tbl, col, vals) => Self::resolve_column(tbl, col, default_table).is_in(vals),
-            Self::NotIn(tbl, col, vals) => {
-                Self::resolve_column(tbl, col, default_table).is_not_in(vals)
+            Self::Compare(col, op, val) => apply_cmp(col.resolve(default_table), op, val.into()),
+            Self::In(col, vals, false) => col.resolve(default_table).is_in(vals),
+            Self::In(col, vals, true) => col.resolve(default_table).is_not_in(vals),
+            Self::Null(col, false) => col.resolve(default_table).is_null(),
+            Self::Null(col, true) => col.resolve(default_table).is_not_null(),
+            Self::Like(col, pattern, false) => col.resolve(default_table).like(pattern),
+            Self::Like(col, pattern, true) => col.resolve(default_table).not_like(pattern),
+            Self::Between(col, low, high, false) => col.resolve(default_table).between(low, high),
+            Self::Between(col, low, high, true) => {
+                col.resolve(default_table).not_between(low, high)
             }
-            Self::IsNull(tbl, col) => Self::resolve_column(tbl, col, default_table).is_null(),
-            Self::IsNotNull(tbl, col) => {
-                Self::resolve_column(tbl, col, default_table).is_not_null()
-            }
-            Self::Like(tbl, col, pattern) => {
-                Self::resolve_column(tbl, col, default_table).like(pattern)
-            }
-            Self::NotLike(tbl, col, pattern) => {
-                Self::resolve_column(tbl, col, default_table).not_like(pattern)
-            }
-            Self::Between(tbl, col, low, high) => {
-                Self::resolve_column(tbl, col, default_table).between(low, high)
-            }
-            Self::NotBetween(tbl, col, low, high) => {
-                Self::resolve_column(tbl, col, default_table).not_between(low, high)
-            }
-            Self::Any(tbl, col, vals) => {
-                // Note: SeaQuery's ANY requires subquery; this is simplified for direct value array
-                Self::resolve_column(tbl, col, default_table).is_in(vals)
-            }
-            Self::ColEq(tbl1, col1, tbl2, col2) => {
-                let left = table_column(tbl1, col1);
-                let right = table_column(tbl2, col2);
-                Expr::col(left).eq(Expr::col(right))
-            }
-            Self::ColNe(tbl1, col1, tbl2, col2) => {
-                let left = table_column(tbl1, col1);
-                let right = table_column(tbl2, col2);
-                Expr::col(left).ne(Expr::col(right))
-            }
-            Self::ColGt(tbl1, col1, tbl2, col2) => {
-                let left = table_column(tbl1, col1);
-                let right = table_column(tbl2, col2);
-                Expr::col(left).gt(Expr::col(right))
-            }
-            Self::ColGte(tbl1, col1, tbl2, col2) => {
-                let left = table_column(tbl1, col1);
-                let right = table_column(tbl2, col2);
-                Expr::col(left).gte(Expr::col(right))
-            }
-            Self::ColLt(tbl1, col1, tbl2, col2) => {
-                let left = table_column(tbl1, col1);
-                let right = table_column(tbl2, col2);
-                Expr::col(left).lt(Expr::col(right))
-            }
-            Self::ColLte(tbl1, col1, tbl2, col2) => {
-                let left = table_column(tbl1, col1);
-                let right = table_column(tbl2, col2);
-                Expr::col(left).lte(Expr::col(right))
+            Self::ColCompare(left, op, right) => {
+                apply_cmp(left.resolve(default_table), op, right.resolve(default_table))
             }
             Self::And(filters) => {
                 let mut exprs = filters.into_iter().map(|f| f.into_expr(default_table));
                 exprs.next().map_or_else(
-                    || Expr::value(true), // no filters, so all conditions satisfied, hence `true`
+                    || Expr::value(true),
                     |first| exprs.fold(first, sea_query::SimpleExpr::and),
                 )
             }
             Self::Or(filters) => {
                 let mut exprs = filters.into_iter().map(|f| f.into_expr(default_table));
                 exprs.next().map_or_else(
-                    || Expr::value(false), // no filters, so 0 conditions satisfied, hence `false`
+                    || Expr::value(false),
                     |first| exprs.fold(first, sea_query::SimpleExpr::or),
                 )
             }
@@ -152,174 +128,228 @@ impl Filter {
         }
     }
 
-    // Convenience constructors for common single-table queries
-
-    /// Creates an equality filter (column = value).
+    /// Qualifies an existing filter with a specific table name.
+    ///
+    /// Applies recursively to nested combinators (`And`/`Or`/`Not`). For column-to-column
+    /// comparisons (`ColCompare`) the table qualifiers are already explicit and this is a no-op.
     #[must_use]
-    pub fn eq(col: &'static str, val: impl Into<Value>) -> Self {
-        Self::Eq(None, col, val.into())
+    pub fn in_table(self, table: &'static str) -> Self {
+        let set = |col: ColRef| ColRef {
+            table: Some(table),
+            ..col
+        };
+        match self {
+            Self::Compare(col, op, v) => Self::Compare(set(col), op, v),
+            Self::In(col, vals, neg) => Self::In(set(col), vals, neg),
+            Self::Null(col, neg) => Self::Null(set(col), neg),
+            Self::Like(col, pat, neg) => Self::Like(set(col), pat, neg),
+            Self::Between(col, lo, hi, neg) => Self::Between(set(col), lo, hi, neg),
+            Self::And(filters) => {
+                Self::And(filters.into_iter().map(|f| f.in_table(table)).collect())
+            }
+            Self::Or(filters) => Self::Or(filters.into_iter().map(|f| f.in_table(table)).collect()),
+            Self::Not(inner) => Self::Not(Box::new(inner.in_table(table))),
+            other @ Self::ColCompare(..) => other,
+        }
     }
+}
 
-    /// Creates an inequality filter (column != value).
-    #[must_use]
-    pub fn ne(col: &'static str, val: impl Into<Value>) -> Self {
-        Self::Ne(None, col, val.into())
-    }
+macro_rules! cmp_ctor {
+    ($name:ident, $op:ident, $doc:literal) => {
+        #[doc = $doc]
+        #[must_use]
+        pub fn $name(col: &'static str, val: impl Into<Value>) -> Self {
+            Self::Compare(ColRef::unqualified(col), CmpOp::$op, val.into())
+        }
+    };
+}
 
-    /// Creates a greater-than filter (column > value).
-    #[must_use]
-    pub fn gt(col: &'static str, val: impl Into<Value>) -> Self {
-        Self::Gt(None, col, val.into())
-    }
+macro_rules! table_cmp_ctor {
+    ($name:ident, $op:ident, $doc:literal) => {
+        #[doc = $doc]
+        #[must_use]
+        pub fn $name(table: &'static str, col: &'static str, val: impl Into<Value>) -> Self {
+            Self::Compare(ColRef::qualified(table, col), CmpOp::$op, val.into())
+        }
+    };
+}
 
-    /// Creates a greater-than-or-equal filter (column >= value).
-    #[must_use]
-    pub fn gte(col: &'static str, val: impl Into<Value>) -> Self {
-        Self::Gte(None, col, val.into())
-    }
+macro_rules! list_ctor {
+    ($name:ident, $negated:literal, $doc:literal) => {
+        #[doc = $doc]
+        #[must_use]
+        pub fn $name(col: &'static str, vals: impl IntoIterator<Item = impl Into<Value>>) -> Self {
+            Self::In(ColRef::unqualified(col), vals.into_iter().map(Into::into).collect(), $negated)
+        }
+    };
+}
 
-    /// Creates a less-than filter (column < value).
-    #[must_use]
-    pub fn lt(col: &'static str, val: impl Into<Value>) -> Self {
-        Self::Lt(None, col, val.into())
-    }
+macro_rules! table_list_ctor {
+    ($name:ident, $negated:literal, $doc:literal) => {
+        #[doc = $doc]
+        #[must_use]
+        pub fn $name(
+            table: &'static str, col: &'static str,
+            vals: impl IntoIterator<Item = impl Into<Value>>,
+        ) -> Self {
+            Self::In(
+                ColRef::qualified(table, col),
+                vals.into_iter().map(Into::into).collect(),
+                $negated,
+            )
+        }
+    };
+}
 
-    /// Creates a less-than-or-equal filter (column <= value).
-    #[must_use]
-    pub fn lte(col: &'static str, val: impl Into<Value>) -> Self {
-        Self::Lte(None, col, val.into())
-    }
+impl Filter {
+    // Convenience constructors for common single-table queries.
 
-    /// Creates an IN filter (column IN (values)).
-    #[must_use]
-    pub fn r#in(col: &'static str, vals: impl IntoIterator<Item = impl Into<Value>>) -> Self {
-        Self::In(None, col, vals.into_iter().map(Into::into).collect())
-    }
+    cmp_ctor!(eq, Eq, "Creates an equality filter (column = value).");
 
-    /// Creates a NOT IN filter (column NOT IN (values)).
-    #[must_use]
-    pub fn not_in(col: &'static str, vals: impl IntoIterator<Item = impl Into<Value>>) -> Self {
-        Self::NotIn(None, col, vals.into_iter().map(Into::into).collect())
-    }
+    cmp_ctor!(ne, Ne, "Creates an inequality filter (column != value).");
+
+    cmp_ctor!(gt, Gt, "Creates a greater-than filter (column > value).");
+
+    cmp_ctor!(gte, Gte, "Creates a greater-than-or-equal filter (column >= value).");
+
+    cmp_ctor!(lt, Lt, "Creates a less-than filter (column < value).");
+
+    cmp_ctor!(lte, Lte, "Creates a less-than-or-equal filter (column <= value).");
+
+    list_ctor!(r#in, false, "Creates an IN filter (column IN (values)).");
+
+    list_ctor!(not_in, true, "Creates a NOT IN filter (column NOT IN (values)).");
+
+    // Table-qualified variants. Equivalent to constructing the unqualified filter and
+    // calling `.in_table(...)` on the result, but kept as named ctors for ergonomics.
+
+    table_cmp_ctor!(
+        table_eq,
+        Eq,
+        "Creates a table-qualified equality filter (table.column = value)."
+    );
+
+    table_cmp_ctor!(
+        table_ne,
+        Ne,
+        "Creates a table-qualified inequality filter (table.column != value)."
+    );
+
+    table_cmp_ctor!(
+        table_gt,
+        Gt,
+        "Creates a table-qualified greater-than filter (table.column > value)."
+    );
+
+    table_cmp_ctor!(
+        table_gte,
+        Gte,
+        "Creates a table-qualified greater-than-or-equal filter (table.column >= value)."
+    );
+
+    table_cmp_ctor!(
+        table_lt,
+        Lt,
+        "Creates a table-qualified less-than filter (table.column < value)."
+    );
+
+    table_cmp_ctor!(
+        table_lte,
+        Lte,
+        "Creates a table-qualified less-than-or-equal filter (table.column <= value)."
+    );
+
+    table_list_ctor!(
+        table_in,
+        false,
+        "Creates a table-qualified IN filter (table.column IN (values))."
+    );
+
+    table_list_ctor!(
+        table_not_in,
+        true,
+        "Creates a table-qualified NOT IN filter (table.column NOT IN (values))."
+    );
 
     /// Creates an IS NULL filter.
     #[must_use]
     pub const fn is_null(col: &'static str) -> Self {
-        Self::IsNull(None, col)
+        Self::Null(ColRef::unqualified(col), false)
     }
 
     /// Creates an IS NOT NULL filter.
     #[must_use]
     pub const fn is_not_null(col: &'static str) -> Self {
-        Self::IsNotNull(None, col)
+        Self::Null(ColRef::unqualified(col), true)
     }
 
     /// Creates a LIKE filter with pattern matching.
     #[must_use]
     pub const fn like(col: &'static str, pattern: String) -> Self {
-        Self::Like(None, col, pattern)
+        Self::Like(ColRef::unqualified(col), pattern, false)
     }
 
     /// Creates a NOT LIKE filter with pattern matching.
     #[must_use]
     pub const fn not_like(col: &'static str, pattern: String) -> Self {
-        Self::NotLike(None, col, pattern)
+        Self::Like(ColRef::unqualified(col), pattern, true)
     }
 
     /// Creates a BETWEEN filter (column BETWEEN low AND high).
     #[must_use]
     pub fn between(col: &'static str, low: impl Into<Value>, high: impl Into<Value>) -> Self {
-        Self::Between(None, col, low.into(), high.into())
+        Self::Between(ColRef::unqualified(col), low.into(), high.into(), false)
     }
 
     /// Creates a NOT BETWEEN filter.
     #[must_use]
     pub fn not_between(col: &'static str, low: impl Into<Value>, high: impl Into<Value>) -> Self {
-        Self::NotBetween(None, col, low.into(), high.into())
+        Self::Between(ColRef::unqualified(col), low.into(), high.into(), true)
     }
 
-    /// Creates an ANY filter (column = ANY(values)).
+    // Logical combinators (alternatives to the bare enum variants).
+
+    /// Combines filters with logical AND. Empty list evaluates to `true`.
     #[must_use]
-    pub fn any(col: &'static str, vals: impl IntoIterator<Item = impl Into<Value>>) -> Self {
-        Self::Any(None, col, vals.into_iter().map(Into::into).collect())
+    pub fn and(filters: impl IntoIterator<Item = Self>) -> Self {
+        Self::And(filters.into_iter().collect())
     }
 
-    // Table-qualified variants for joined queries
-
-    /// Creates a table-qualified equality filter (table.column = value).
+    /// Combines filters with logical OR. Empty list evaluates to `false`.
     #[must_use]
-    pub fn table_eq(table: &'static str, col: &'static str, val: impl Into<Value>) -> Self {
-        Self::Eq(Some(table), col, val.into())
+    pub fn or(filters: impl IntoIterator<Item = Self>) -> Self {
+        Self::Or(filters.into_iter().collect())
     }
 
-    /// Creates a table-qualified inequality filter (table.column != value).
+    /// Logically negates a filter.
     #[must_use]
-    pub fn table_ne(table: &'static str, col: &'static str, val: impl Into<Value>) -> Self {
-        Self::Ne(Some(table), col, val.into())
-    }
-
-    /// Creates a table-qualified greater-than filter (table.column > value).
-    #[must_use]
-    pub fn table_gt(table: &'static str, col: &'static str, val: impl Into<Value>) -> Self {
-        Self::Gt(Some(table), col, val.into())
-    }
-
-    /// Creates a table-qualified greater-than-or-equal filter (table.column >= value).
-    #[must_use]
-    pub fn table_gte(table: &'static str, col: &'static str, val: impl Into<Value>) -> Self {
-        Self::Gte(Some(table), col, val.into())
-    }
-
-    /// Creates a table-qualified less-than filter (table.column < value).
-    #[must_use]
-    pub fn table_lt(table: &'static str, col: &'static str, val: impl Into<Value>) -> Self {
-        Self::Lt(Some(table), col, val.into())
-    }
-
-    /// Creates a table-qualified less-than-or-equal filter (table.column <= value).
-    #[must_use]
-    pub fn table_lte(table: &'static str, col: &'static str, val: impl Into<Value>) -> Self {
-        Self::Lte(Some(table), col, val.into())
-    }
-
-    /// Creates a table-qualified IN filter (table.column IN (values)).
-    #[must_use]
-    pub fn table_in(
-        table: &'static str, col: &'static str, vals: impl IntoIterator<Item = impl Into<Value>>,
-    ) -> Self {
-        Self::In(Some(table), col, vals.into_iter().map(Into::into).collect())
-    }
-
-    /// Creates a table-qualified NOT IN filter (table.column NOT IN (values)).
-    #[must_use]
-    pub fn table_not_in(
-        table: &'static str, col: &'static str, vals: impl IntoIterator<Item = impl Into<Value>>,
-    ) -> Self {
-        Self::NotIn(Some(table), col, vals.into_iter().map(Into::into).collect())
+    #[allow(clippy::should_implement_trait)] // logical NOT ctor; std::ops::Not signature is unsuitable
+    pub fn not(filter: Self) -> Self {
+        Self::Not(Box::new(filter))
     }
 
     /// Creates a table-qualified IS NULL filter (table.column IS NULL).
     #[must_use]
     pub const fn table_is_null(table: &'static str, col: &'static str) -> Self {
-        Self::IsNull(Some(table), col)
+        Self::Null(ColRef::qualified(table, col), false)
     }
 
     /// Creates a table-qualified IS NOT NULL filter (table.column IS NOT NULL).
     #[must_use]
     pub const fn table_is_not_null(table: &'static str, col: &'static str) -> Self {
-        Self::IsNotNull(Some(table), col)
+        Self::Null(ColRef::qualified(table, col), true)
     }
 
     /// Creates a table-qualified LIKE filter (table.column LIKE pattern).
     #[must_use]
     pub const fn table_like(table: &'static str, col: &'static str, pattern: String) -> Self {
-        Self::Like(Some(table), col, pattern)
+        Self::Like(ColRef::qualified(table, col), pattern, false)
     }
 
     /// Creates a table-qualified NOT LIKE filter (table.column NOT LIKE pattern).
     #[must_use]
     pub const fn table_not_like(table: &'static str, col: &'static str, pattern: String) -> Self {
-        Self::NotLike(Some(table), col, pattern)
+        Self::Like(ColRef::qualified(table, col), pattern, true)
     }
 
     /// Creates a table-qualified BETWEEN filter (table.column BETWEEN low AND high).
@@ -327,7 +357,7 @@ impl Filter {
     pub fn table_between(
         table: &'static str, col: &'static str, low: impl Into<Value>, high: impl Into<Value>,
     ) -> Self {
-        Self::Between(Some(table), col, low.into(), high.into())
+        Self::Between(ColRef::qualified(table, col), low.into(), high.into(), false)
     }
 
     /// Creates a table-qualified NOT BETWEEN filter.
@@ -335,63 +365,19 @@ impl Filter {
     pub fn table_not_between(
         table: &'static str, col: &'static str, low: impl Into<Value>, high: impl Into<Value>,
     ) -> Self {
-        Self::NotBetween(Some(table), col, low.into(), high.into())
+        Self::Between(ColRef::qualified(table, col), low.into(), high.into(), true)
     }
 
-    /// Creates a table-qualified ANY filter (table.column = ANY(values)).
-    #[must_use]
-    pub fn table_any(
-        table: &'static str, col: &'static str, vals: impl IntoIterator<Item = impl Into<Value>>,
-    ) -> Self {
-        Self::Any(Some(table), col, vals.into_iter().map(Into::into).collect())
-    }
-
-    /// Compare two columns for equality.
-    /// Table names are required since we're comparing columns from different tables.
+    /// Compares two columns for equality (`table1.col1 = table2.col2`).
+    /// Used primarily in JOIN conditions.
     #[must_use]
     pub const fn col_eq(
         table1: &'static str, col1: &'static str, table2: &'static str, col2: &'static str,
     ) -> Self {
-        Self::ColEq(table1, col1, table2, col2)
-    }
-
-    /// Creates a column-to-column inequality filter (table1.col1 != table2.col2).
-    #[must_use]
-    pub const fn col_ne(
-        table1: &'static str, col1: &'static str, table2: &'static str, col2: &'static str,
-    ) -> Self {
-        Self::ColNe(table1, col1, table2, col2)
-    }
-
-    /// Creates a column-to-column greater-than filter (table1.col1 > table2.col2).
-    #[must_use]
-    pub const fn col_gt(
-        table1: &'static str, col1: &'static str, table2: &'static str, col2: &'static str,
-    ) -> Self {
-        Self::ColGt(table1, col1, table2, col2)
-    }
-
-    /// Creates a column-to-column greater-than-or-equal filter (table1.col1 >= table2.col2).
-    #[must_use]
-    pub const fn col_gte(
-        table1: &'static str, col1: &'static str, table2: &'static str, col2: &'static str,
-    ) -> Self {
-        Self::ColGte(table1, col1, table2, col2)
-    }
-
-    /// Creates a column-to-column less-than filter (table1.col1 < table2.col2).
-    #[must_use]
-    pub const fn col_lt(
-        table1: &'static str, col1: &'static str, table2: &'static str, col2: &'static str,
-    ) -> Self {
-        Self::ColLt(table1, col1, table2, col2)
-    }
-
-    /// Creates a column-to-column less-than-or-equal filter (table1.col1 <= table2.col2).
-    #[must_use]
-    pub const fn col_lte(
-        table1: &'static str, col1: &'static str, table2: &'static str, col2: &'static str,
-    ) -> Self {
-        Self::ColLte(table1, col1, table2, col2)
+        Self::ColCompare(
+            ColRef::qualified(table1, col1),
+            CmpOp::Eq,
+            ColRef::qualified(table2, col2),
+        )
     }
 }

--- a/crates/orm/src/insert.rs
+++ b/crates/orm/src/insert.rs
@@ -3,23 +3,24 @@ use std::marker::PhantomData;
 use anyhow::Result;
 use sea_query::{Alias, OnConflict, SimpleExpr, Value};
 
-use crate::entity::{Entity, EntityValues, values_to_wasi_datatypes};
-use crate::query::{Query, QueryBuilder};
+use crate::entity::{Entity, EntityValues};
+use crate::query::{Query, finish};
 
 /// Builder for constructing INSERT queries.
 pub struct InsertBuilder<M: Entity> {
     values: Vec<(&'static str, Value)>,
-    conflict: Option<ConflictStrategy>,
+    conflict: Option<Conflict>,
     _marker: PhantomData<M>,
 }
 
-enum ConflictStrategy {
-    DoNothing { target: ConflictTarget },
-    DoUpdate { target: ConflictTarget, columns: Vec<&'static str> },
+struct Conflict {
+    target: Vec<&'static str>,
+    action: ConflictAction,
 }
 
-enum ConflictTarget {
-    Columns(Vec<&'static str>),
+enum ConflictAction {
+    Nothing,
+    Update(Vec<&'static str>),
 }
 
 impl<M: Entity> Default for InsertBuilder<M> {
@@ -62,68 +63,53 @@ impl<M: Entity> InsertBuilder<M> {
         self
     }
 
-    /// Handle conflicts on specified columns. Call ``do_update()`` or ``do_nothing()`` after.
+    /// Handle conflicts on the specified target columns. The default action is `DO NOTHING`;
+    /// chain [`Self::do_update`] or [`Self::do_update_all`] to switch to `DO UPDATE`.
     #[must_use]
     pub fn on_conflict_columns(mut self, columns: &[&'static str]) -> Self {
-        self.conflict = Some(ConflictStrategy::DoNothing {
-            target: ConflictTarget::Columns(columns.to_vec()),
+        self.conflict = Some(Conflict {
+            target: columns.to_vec(),
+            action: ConflictAction::Nothing,
         });
         self
     }
 
-    /// Shorthand for single column conflict
+    /// Shorthand for a single-column conflict target.
     #[must_use]
     pub fn on_conflict(self, column: &'static str) -> Self {
         self.on_conflict_columns(&[column])
     }
 
-    /// On conflict, do nothing (ignore the insert)
+    /// On conflict, do nothing. (Default action for [`Self::on_conflict_columns`]; provided
+    /// for explicit-verb call sites.)
     #[must_use]
     pub fn do_nothing(mut self) -> Self {
-        if let Some(ConflictStrategy::DoNothing { target }) = self.conflict.take() {
-            self.conflict = Some(ConflictStrategy::DoNothing { target });
+        if let Some(conflict) = self.conflict.as_mut() {
+            conflict.action = ConflictAction::Nothing;
         }
         self
     }
 
-    /// On conflict, update the specified columns with excluded (new) values
+    /// On conflict, update the specified columns with excluded (new) values.
     #[must_use]
     pub fn do_update(mut self, columns: &[&'static str]) -> Self {
-        if let Some(conflict) = self.conflict.take() {
-            let target = match conflict {
-                ConflictStrategy::DoNothing { target }
-                | ConflictStrategy::DoUpdate { target, .. } => target,
-            };
-            self.conflict = Some(ConflictStrategy::DoUpdate {
-                target,
-                columns: columns.to_vec(),
-            });
+        if let Some(conflict) = self.conflict.as_mut() {
+            conflict.action = ConflictAction::Update(columns.to_vec());
         }
         self
     }
 
-    /// On conflict, update all columns except the conflict target
+    /// On conflict, update all columns except the conflict target.
     #[must_use]
     pub fn do_update_all(mut self) -> Self {
-        if let Some(conflict) = self.conflict.take() {
-            let target = match conflict {
-                ConflictStrategy::DoNothing { target }
-                | ConflictStrategy::DoUpdate { target, .. } => target,
-            };
-            let conflict_cols: Vec<&str> = match &target {
-                ConflictTarget::Columns(cols) => cols.clone(),
-            };
+        if let Some(conflict) = self.conflict.as_mut() {
             let update_cols: Vec<&'static str> = self
                 .values
                 .iter()
                 .map(|(col, _)| *col)
-                .filter(|col| !conflict_cols.contains(col))
+                .filter(|col| !conflict.target.contains(col))
                 .collect();
-
-            self.conflict = Some(ConflictStrategy::DoUpdate {
-                target,
-                columns: update_cols,
-            });
+            conflict.action = ConflictAction::Update(update_cols);
         }
         self
     }
@@ -144,34 +130,19 @@ impl<M: Entity> InsertBuilder<M> {
         statement.columns(columns);
         statement.values_panic(row);
 
-        // Handle ON CONFLICT clause
-        if let Some(conflict) = self.conflict {
-            let on_conflict = match conflict {
-                ConflictStrategy::DoNothing { target } => {
-                    let ConflictTarget::Columns(cols) = target;
-                    OnConflict::columns(cols.into_iter().map(Alias::new)).do_nothing().to_owned()
+        if let Some(Conflict { target, action }) = self.conflict {
+            let mut on_conflict = OnConflict::columns(target.into_iter().map(Alias::new));
+            match action {
+                ConflictAction::Nothing => {
+                    on_conflict.do_nothing();
                 }
-                ConflictStrategy::DoUpdate { target, columns } => {
-                    let ConflictTarget::Columns(cols) = target;
-                    OnConflict::columns(cols.into_iter().map(Alias::new))
-                        .update_columns(columns.into_iter().map(Alias::new))
-                        .to_owned()
+                ConflictAction::Update(cols) => {
+                    on_conflict.update_columns(cols.into_iter().map(Alias::new));
                 }
-            };
-
+            }
             statement.on_conflict(on_conflict);
         }
 
-        let (sql, values) = statement.build(QueryBuilder::default());
-        let params = values_to_wasi_datatypes(values)?;
-
-        tracing::debug!(
-            table = M::TABLE,
-            sql = %sql,
-            param_count = params.len(),
-            "InsertBuilder generated SQL"
-        );
-
-        Ok(Query { sql, params })
+        finish(&statement, M::TABLE, "insert")
     }
 }

--- a/crates/orm/src/join.rs
+++ b/crates/orm/src/join.rs
@@ -14,61 +14,26 @@ pub struct Join {
 /// Join types supported by the ORM.
 #[derive(Clone, Copy)]
 pub enum JoinKind {
+    /// `INNER JOIN`
     Inner,
+    /// `LEFT JOIN`
     Left,
+    /// `RIGHT JOIN`
     Right,
+    /// `FULL OUTER JOIN`
     Full,
 }
 
 impl Join {
-    /// Creates a JOIN (defaults to INNER JOIN).
+    /// Creates a JOIN of the given kind.
     #[must_use]
-    pub const fn new(table: &'static str, on: Filter) -> Self {
+    pub const fn new(table: &'static str, kind: JoinKind, on: Filter) -> Self {
         Self {
             table,
             alias: None,
             on,
-            kind: JoinKind::Inner,
+            kind,
         }
-    }
-
-    /// Creates a LEFT JOIN.
-    #[must_use]
-    pub const fn left(table: &'static str, on: Filter) -> Self {
-        Self {
-            table,
-            alias: None,
-            on,
-            kind: JoinKind::Left,
-        }
-    }
-
-    /// Creates a RIGHT JOIN.
-    #[must_use]
-    pub const fn right(table: &'static str, on: Filter) -> Self {
-        Self {
-            table,
-            alias: None,
-            on,
-            kind: JoinKind::Right,
-        }
-    }
-
-    /// Creates a FULL OUTER JOIN.
-    #[must_use]
-    pub const fn full(table: &'static str, on: Filter) -> Self {
-        Self {
-            table,
-            alias: None,
-            on,
-            kind: JoinKind::Full,
-        }
-    }
-
-    /// Creates an INNER JOIN (alias for `new`).
-    #[must_use]
-    pub const fn inner(table: &'static str, on: Filter) -> Self {
-        Self::new(table, on)
     }
 
     /// Sets an alias for the joined table.
@@ -88,6 +53,26 @@ impl Join {
             kind: self.kind.into_join_type(),
         }
     }
+}
+
+macro_rules! join_ctor {
+    ($name:ident, $kind:ident, $doc:literal) => {
+        #[doc = $doc]
+        #[must_use]
+        pub const fn $name(table: &'static str, on: Filter) -> Self {
+            Self::new(table, JoinKind::$kind, on)
+        }
+    };
+}
+
+impl Join {
+    join_ctor!(inner, Inner, "Creates an INNER JOIN.");
+
+    join_ctor!(left, Left, "Creates a LEFT JOIN.");
+
+    join_ctor!(right, Right, "Creates a RIGHT JOIN.");
+
+    join_ctor!(full, Full, "Creates a FULL OUTER JOIN.");
 }
 
 impl JoinKind {

--- a/crates/orm/src/lib.rs
+++ b/crates/orm/src/lib.rs
@@ -12,9 +12,9 @@ mod update;
 
 pub use delete::DeleteBuilder;
 pub use entity::{Entity, EntityValues, FetchValue};
-pub use filter::Filter;
+pub use filter::{CmpOp, ColRef, Filter};
 pub use insert::InsertBuilder;
-pub use join::Join;
+pub use join::{Join, JoinKind};
 // Re-export basic WASI SQL types for use in query parameters and custom value conversions.
 pub use omnia_wasi_sql::{DataType, Field, Row};
 pub use select::SelectBuilder;

--- a/crates/orm/src/query.rs
+++ b/crates/orm/src/query.rs
@@ -1,36 +1,47 @@
+use anyhow::Result;
 use sea_query::backend::{
     EscapeBuilder, OperLeftAssocDecider, PrecedenceDecider, QuotedBuilder, TableRefBuilder,
 };
 use sea_query::prepare::SqlWriter;
-use sea_query::{BinOper, Oper, Quote, SimpleExpr, SubQueryStatement, Value};
+use sea_query::{
+    BinOper, Oper, QueryStatementBuilder, Quote, SimpleExpr, SubQueryStatement, Value,
+};
 
 use crate::DataType;
+use crate::entity::values_to_wasi_datatypes;
 
 pub struct Query {
     pub sql: String,
     pub params: Vec<DataType>,
 }
 
-pub struct QueryBuilder {
-    pub quote: Quote,
-    pub placeholder: &'static str, // "?" or "$"
-    pub numbered: bool,            // false for "?", true for "$1, $2, ..."
+/// Finalises a `SeaQuery` statement into a [`Query`]: renders the SQL, converts the bound
+/// values to WASI [`DataType`]s, and emits a uniform `tracing::debug!` event.
+pub fn finish<S: QueryStatementBuilder>(
+    stmt: &S, table: &'static str, kind: &'static str,
+) -> Result<Query> {
+    let (sql, values) = stmt.build_any(&QueryBuilder);
+    let params = values_to_wasi_datatypes(values)?;
+
+    tracing::debug!(
+        table,
+        kind,
+        sql = %sql,
+        param_count = params.len(),
+        "ORM query built",
+    );
+
+    Ok(Query { sql, params })
 }
 
-impl Default for QueryBuilder {
-    // should work for `Postgres` and `Sqlite`
-    fn default() -> Self {
-        Self {
-            quote: Quote::new(b'"'),
-            placeholder: "$",
-            numbered: true,
-        }
-    }
-}
+/// Backend-agnostic `SeaQuery` query builder configured for Postgres/SQLite dialects:
+/// double-quoted identifiers and numbered placeholders (`$1`, `$2`, ...).
+#[derive(Default)]
+pub struct QueryBuilder;
 
 impl QuotedBuilder for QueryBuilder {
     fn quote(&self) -> Quote {
-        self.quote
+        Quote::new(b'"')
     }
 }
 
@@ -73,6 +84,6 @@ impl sea_query::backend::QueryBuilder for QueryBuilder {
     }
 
     fn placeholder(&self) -> (&str, bool) {
-        (self.placeholder, self.numbered)
+        ("$", true)
     }
 }

--- a/crates/orm/src/select.rs
+++ b/crates/orm/src/select.rs
@@ -2,10 +2,10 @@ use std::marker::PhantomData;
 
 use sea_query::{Alias, ColumnRef, IntoIden, Order, SimpleExpr};
 
-use crate::entity::{Entity, values_to_wasi_datatypes};
+use crate::entity::Entity;
 use crate::filter::Filter;
 use crate::join::{Join, JoinSpec};
-use crate::query::{Query, QueryBuilder};
+use crate::query::{Query, finish};
 
 /// Builder for constructing SELECT queries.
 pub struct SelectBuilder<M: Entity> {
@@ -148,17 +148,7 @@ impl<M: Entity> SelectBuilder<M> {
             statement.order_by(column, order);
         }
 
-        let (sql, values) = statement.build(QueryBuilder::default());
-        let params = values_to_wasi_datatypes(values)?;
-
-        tracing::debug!(
-            table = M::TABLE,
-            sql = %sql,
-            param_count = params.len(),
-            "SelectBuilder generated SQL"
-        );
-
-        Ok(Query { sql, params })
+        finish(&statement, M::TABLE, "select")
     }
 }
 

--- a/crates/orm/src/update.rs
+++ b/crates/orm/src/update.rs
@@ -3,9 +3,9 @@ use std::marker::PhantomData;
 use anyhow::Result;
 use sea_query::{Alias, SimpleExpr, Value};
 
-use crate::entity::{Entity, values_to_wasi_datatypes};
+use crate::entity::Entity;
 use crate::filter::Filter;
-use crate::query::{Query, QueryBuilder};
+use crate::query::{Query, finish};
 
 /// Builder for constructing UPDATE queries.
 pub struct UpdateBuilder<M: Entity> {
@@ -78,16 +78,6 @@ impl<M: Entity> UpdateBuilder<M> {
             statement.returning_col(Alias::new(column));
         }
 
-        let (sql, values) = statement.build(QueryBuilder::default());
-        let params = values_to_wasi_datatypes(values)?;
-
-        tracing::debug!(
-            table = M::TABLE,
-            sql = %sql,
-            param_count = params.len(),
-            "UpdateBuilder generated SQL"
-        );
-
-        Ok(Query { sql, params })
+        finish(&statement, M::TABLE, "update")
     }
 }

--- a/crates/orm/src/usage.md
+++ b/crates/orm/src/usage.md
@@ -218,9 +218,6 @@ Filter::not_between("age", 13, 19)
 // IN clause
 Filter::in("status", vec!["active", "pending", "approved"])
 Filter::not_in("user_id", vec![1, 2, 3])
-
-// ANY clause (for array columns)
-Filter::any("tags", vec!["rust", "programming"])
 ```
 
 ### Table-Qualified Filters (for Joins)
@@ -230,14 +227,16 @@ Filter::any("tags", vec!["rust", "programming"])
 Filter::table_eq("posts", "published", true)
 Filter::table_gt("users", "age", 18)
 Filter::table_like("posts", "title", "%rust%")
+
+// Or qualify an existing filter (applies recursively to nested combinators):
+Filter::eq("published", true).in_table("posts")
 ```
 
 ### Column-to-Column Comparisons
 
 ```rust
-// Compare columns from different tables
+// Compare columns from different tables (used in JOIN ON clauses).
 Filter::col_eq("posts", "author_id", "users", "id")
-Filter::col_gt("orders", "total", "users", "credit_limit")
 ```
 
 ### Logical Combinators

--- a/crates/orm/tests/filter.rs
+++ b/crates/orm/tests/filter.rs
@@ -73,7 +73,7 @@ fn filter_in_empty_array() {
 
     // NOTE: SeaQuery generates invalid SQL for empty IN clauses: WHERE ($1) = ($2)
     // This is a known limitation - callers should avoid empty IN arrays
-    // or use Filter::And(vec![]) to short-circuit to no filter
+    // or use Filter::and([]) to short-circuit to no filter
     assert_sql_contains(&query.sql, &["WHERE", "($1)", "($2)"]);
     assert_eq!(query.params.len(), 2);
 }
@@ -101,16 +101,6 @@ fn filter_is_not_null() {
 
     assert_sql_contains(&query.sql, &["WHERE", "users.name", "IS NOT (NULL)"]);
     assert_eq!(query.params.len(), 0);
-}
-
-#[test]
-fn filter_any_values() {
-    let query =
-        SelectBuilder::<User>::new().r#where(Filter::any("id", vec![1, 2, 3])).build().unwrap();
-
-    // ANY is implemented as IN for direct value arrays
-    assert_sql_contains(&query.sql, &["WHERE", "users.id", "IN"]);
-    assert_eq!(query.params.len(), 3);
 }
 
 #[test]
@@ -147,30 +137,28 @@ fn filter_table_qualified_in() {
 }
 
 #[test]
-fn filter_col_ne() {
-    // Test column-to-column comparison (representative of all col_* variants)
+fn filter_col_compare() {
     let query = SelectBuilder::<User>::new()
-        .join(Join::left("user_roles", Filter::col_ne("users", "id", "user_roles", "user_id")))
+        .join(Join::left("user_roles", Filter::col_eq("users", "id", "user_roles", "user_id")))
         .build()
         .unwrap();
 
     assert_sql_contains(
         &query.sql,
-        &["LEFT JOIN", "user_roles", "ON", "users.id", "<>", "user_roles.user_id"],
+        &["LEFT JOIN", "user_roles", "ON", "users.id", "=", "user_roles.user_id"],
     );
 }
 
 #[test]
 fn filter_nested_and_or() {
     let query = SelectBuilder::<User>::new()
-        .r#where(Filter::And(vec![
-            Filter::Or(vec![Filter::eq("active", true), Filter::eq("id", 1)]),
+        .r#where(Filter::and([
+            Filter::or([Filter::eq("active", true), Filter::eq("id", 1)]),
             Filter::gt("id", 0),
         ]))
         .build()
         .unwrap();
 
-    // Should have nested boolean logic
     assert_sql_contains(&query.sql, &["WHERE"]);
     assert!(query.params.len() >= 2);
 }
@@ -178,9 +166,9 @@ fn filter_nested_and_or() {
 #[test]
 fn filter_deeply_nested() {
     let query = SelectBuilder::<User>::new()
-        .r#where(Filter::Or(vec![
-            Filter::And(vec![Filter::eq("active", true), Filter::gt("id", 10)]),
-            Filter::And(vec![Filter::eq("active", false), Filter::lt("id", 5)]),
+        .r#where(Filter::or([
+            Filter::and([Filter::eq("active", true), Filter::gt("id", 10)]),
+            Filter::and([Filter::eq("active", false), Filter::lt("id", 5)]),
         ]))
         .build()
         .unwrap();
@@ -195,7 +183,7 @@ fn filter_deeply_nested() {
 
 #[test]
 fn filter_empty_and() {
-    let query = SelectBuilder::<User>::new().r#where(Filter::And(vec![])).build().unwrap();
+    let query = SelectBuilder::<User>::new().r#where(Filter::and([])).build().unwrap();
 
     // Empty AND should be treated as true (all conditions satisfied)
     assert_sql_contains(&query.sql, &["SELECT", "FROM users"]);
@@ -203,8 +191,19 @@ fn filter_empty_and() {
 
 #[test]
 fn filter_empty_or() {
-    let query = SelectBuilder::<User>::new().r#where(Filter::Or(vec![])).build().unwrap();
+    let query = SelectBuilder::<User>::new().r#where(Filter::or([])).build().unwrap();
 
     // Empty OR should be treated as false (no conditions satisfied)
     assert_sql_contains(&query.sql, &["SELECT", "FROM users"]);
+}
+
+#[test]
+fn filter_in_table_combinator() {
+    // `in_table` qualifies all unqualified column refs (recursively) with the given table.
+    let query = SelectBuilder::<User>::new()
+        .r#where(Filter::eq("active", true).in_table("users"))
+        .build()
+        .unwrap();
+
+    assert_sql_contains(&query.sql, &["WHERE", "users.active", "=", "$1"]);
 }

--- a/crates/orm/tests/orm.rs
+++ b/crates/orm/tests/orm.rs
@@ -96,7 +96,7 @@ fn select_with_ad_hoc_join() {
 #[test]
 fn select_with_or_filter() {
     let query = SelectBuilder::<User>::new()
-        .r#where(Filter::Or(vec![Filter::eq("active", true), Filter::gt("id", 100)]))
+        .r#where(Filter::or([Filter::eq("active", true), Filter::gt("id", 100)]))
         .build()
         .unwrap();
 
@@ -112,7 +112,7 @@ fn select_with_or_filter() {
 #[test]
 fn select_with_not_filter() {
     let query = SelectBuilder::<User>::new()
-        .r#where(Filter::Not(Box::new(Filter::eq("active", false))))
+        .r#where(Filter::not(Filter::eq("active", false)))
         .build()
         .unwrap();
 

--- a/crates/wasi-http/CIRCUIT_BREAKER.md
+++ b/crates/wasi-http/CIRCUIT_BREAKER.md
@@ -1,0 +1,167 @@
+# Circuit Breaker — Simplification & Placement Notes
+
+Findings from a review of `crates/wasi-http/src/host/circuit_breaker.rs` and its
+call-sites in `outbound.rs` / `default_impl.rs`. Two related questions:
+
+1. Can the current implementation be simplified?
+2. If we didn't implement it here, where else could it live?
+
+---
+
+## Part 1 — Simplifying the Current Implementation
+
+The current breaker is ~840 lines (incl. tests): a three-state machine with a
+fault window, a `BucketRegistry`, separate `probe_count` / `success_count`
+counters, and internal `CheckOutcome` / `TripCause` enums used to defer logging
+outside the mutex. Possible cuts, ranked by payoff:
+
+### 1. Collapse `HalfOpen` to a single probe
+
+Today `HalfOpen` tracks `probe_count` (admission cap) **and** `success_count`
+(closes when ≥ `recovery_threshold`). The classic Hystrix/Polly pattern admits
+one probe: success → `Closed`, failure → `Open`.
+
+Removes: `recovery_threshold`, `probe_count`, `success_count`,
+`HTTP_CB_RECOVERY_THRESHOLD`, and ~4 lifecycle tests.
+
+### 2. Drop the fault window; reset on success instead
+
+The fault window stops "1 timeout per hour for 10 hours" from tripping. A
+simpler equivalent: **reset `fault_count` to 0 on every success while
+`Closed`**. You only trip on a consecutive burst, no `Instant` arithmetic, no
+`fault_window_start`, no `HTTP_CB_FAULT_WINDOW_MS`, no boundary-edge test.
+
+`record_success` is currently a no-op in `Closed` — adding the reset there
+deletes the entire window mechanism (~25 lines + tests + 1 env var).
+
+### 3. Drop `BucketRegistry`; use a single global breaker
+
+The bucket abstraction costs a `HashMap`, `Arc<CircuitBreaker>`,
+`ResolvedBreaker`, an "unknown bucket" error path, the `x-omnia-upstream`
+header round-trip, ~6 dedicated tests, and a benchmark group.
+
+If real deployments use 1–3 fixed upstreams, hard-code a single
+`Arc<CircuitBreaker>` in `ResilienceConfig` and delete the registry. ~80 lines
+gone, plus the WASI boundary header.
+
+### 4. Inline `CheckOutcome` / `TripCause` enums
+
+They exist only to defer `tracing::*!` until after the `parking_lot::Mutex` is
+released. `parking_lot` critical sections are very short and `tracing` macros
+are synchronous + cheap — logging inside the lock is fine. Inlining removes
+both enums and the post-match dispatch (~50 lines).
+
+### 5. Drop the test-only `*_at` parametric API
+
+Three pairs of `check`/`check_at`, `record_failure`/`record_failure_at`, etc.
+Either inject a `Clock` trait (more abstraction) or keep just the parametric
+form and always pass `Instant::now()` at the call site.
+
+### 6. Drop `BreakerConfig::validate`
+
+Switch to `NonZeroU32` + `Duration` in the config struct; invalid values
+become unconstructible. Removes 4 validation tests.
+
+### 7. Reach for an off-the-shelf crate
+
+`failsafe-rs` (or a `tower` CB layer) gives you closed/open/half-open in ~10
+LOC of integration. The current breaker isn't exotic enough to justify a
+custom impl once buckets go away.
+
+### Recommended minimum
+
+1, 2, and 4 alone take the file from ~840 → ~400 lines (mostly tests), remove
+two env vars, and the state machine fits on a screen. Buckets stay — they
+add capability rather than just knobs.
+
+---
+
+## Part 2 — Where Else a Circuit Breaker Could Live
+
+Roughly in increasing distance from the application code.
+
+### 1. Runtime/platform layer (sidecar or proxy)
+
+Envoy/Linkerd/Istio do circuit breaking + outlier detection as first-class
+features. Configure per-cluster and every outbound HTTP call is covered.
+
+- **Pros:** zero application code, operator-tuned, language-agnostic.
+- **Cons:** HTTP only — doesn't help `wasi-sql`, `wasi-messaging`,
+  `wasi-blobstore`. Assumes the operator runs a mesh.
+
+Right answer if Omnia is always deployed under an opinionated platform.
+
+### 2. `reqwest` / `tower` middleware (still in `wasi-http`)
+
+Wrap `reqwest::Client` in a `tower::Service`; compose `tower::retry`,
+`tower::timeout`, `tower::load_shed`, and a CB layer (e.g. `failsafe`).
+
+- **Pros:** stays in `wasi-http`, deletes the hand-rolled state machine.
+- **Cons:** pulls in the `tower` ecosystem; stacked middlewares can be opaque.
+
+### 3. Guest-side, via `omnia-sdk`
+
+Move the breaker into the WASM component itself, alongside `OutboundPolicy`.
+
+- **Pros:** portable across host implementations, per-feature isolation is
+  automatic, host stays simpler.
+- **Cons:** if instances are request-scoped the breaker has no memory between
+  calls and is useless; WASM crossing cost per `check` / `record`; can't share
+  trip state across instances without going through the host.
+
+Only viable for long-lived worker guests.
+
+### 4. Generic `Resilient<B: Backend>` adapter in the `omnia` crate
+
+One breaker wrapper any `Backend` can opt into.
+
+- **Pros:** one implementation, reusable across SQL / messaging / blobstore /
+  HTTP.
+- **Cons:** each backend has different fault semantics, so the wrapper needs a
+  `BreakerFault` trait — not obviously simpler than per-interface breakers.
+
+### 5. Per-interface (today's pattern, expanded)
+
+Add breakers to `wasi-sql`, `wasi-messaging`, `wasi-blobstore`,
+`wasi-keyvalue` as needed.
+
+- **Pros:** each tuned to its protocol's fault model.
+- **Cons:** the drivers (`sqlx`, `async-nats`, `aws-sdk-s3`) already have
+  retry/timeout knobs; an extra CB on top is sometimes redundant.
+
+### 6. Skip the breaker; use a simpler primitive
+
+A CB does three jobs: fast-fail when sick, stop piling on, test recovery.
+Most of that comes free from:
+
+- **Concurrency limiter** — `tokio::sync::Semaphore` per upstream caps
+  in-flight requests. When the upstream slows down, new requests reject
+  immediately. ~15 LOC, no state machine.
+- **Strict total-budget timeout** — already present.
+- **Rate limiter / token bucket** — bounds per-upstream load.
+
+A semaphore + the existing timeout covers ~80% of what the breaker actually
+does for you.
+
+---
+
+## Recommendation for this codebase
+
+Given that:
+
+- `wasi-http` is the only crate that has rolled its own breaker,
+- Omnia is intended to be deployable as a standalone binary (no sidecar
+  guarantee),
+- but most real production users *will* be behind a proxy or mesh,
+
+A two-step path is sensible:
+
+1. **Replace the breaker with a `tokio::sync::Semaphore`** keyed by
+   `upstream` — `HTTP_MAX_INFLIGHT_PER_UPSTREAM=N`. Handles "don't pile on a
+   sick host" without state machines or fault windows.
+2. **Document** in the `wasi-http` README that real circuit breaking is the
+   responsibility of an upstream proxy/mesh, and recommend an Envoy snippet.
+
+If a real breaker turns out to be necessary after that, add it back as a
+`tower` middleware on the `reqwest::Client` (option 2 above) — the whole
+`circuit_breaker.rs` file goes away in favour of a maintained crate.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Filter API removals (`any`, extra `col_*` variants) and enum reshaping can break downstream code that constructed filters directly; SQL generation paths were refactored centrally so regressions would affect all CRUD builders.
> 
> **Overview**
> This PR **deduplicates and streamlines the ORM** while tightening a few public APIs.
> 
> **Query building:** `select`, `insert`, `update`, and `delete` builders now share `query::finish`, which renders SQL via `build_any`, converts params to WASI types, and logs a single `tracing::debug!` shape (`kind` + table).
> 
> **Filters:** The large `Filter` enum is collapsed around `ColRef`, `CmpOp`, and negation flags (`In`/`Null`/`Like`/`Between`). New helpers include `Filter::and` / `or` / `not`, recursive `in_table`, and exports for `ColRef` / `CmpOp`. **Removed:** `Filter::any` and column-to-column helpers other than `col_eq` (previously `col_ne`, `col_gt`, etc.). Constructing bare `Filter::And` / `Or` / `Not` is replaced by the named combinators.
> 
> **Entity row mapping:** Primitive `FetchValue` impls are macro-generated; parsing helpers are renamed (`parse_timestamp`, etc.) and tests target `FetchValue` directly.
> 
> **Insert upserts:** ON CONFLICT state is a single `Conflict { target, action }` struct instead of split strategy/target enums.
> 
> **Joins:** `Join::new` takes an explicit `JoinKind`; `inner`/`left`/… are macro-generated. `JoinKind` is re-exported.
> 
> **Docs/tests:** `usage.md` drops `Filter::any` and documents `in_table`. Integration tests follow the new combinator style and add `in_table` coverage.
> 
> **Unrelated:** Adds `crates/wasi-http/CIRCUIT_BREAKER.md` (design notes only; no runtime behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d880b1813f5cd2da14368fdc08da8587aadccb48. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->