### PR TITLE
Instrumentation fix

### DIFF
--- a/crates/wasi-http/src/host/server.rs
+++ b/crates/wasi-http/src/host/server.rs
@@ -20,7 +20,7 @@ use hyper::service::service_fn;
 use omnia::State;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
-use tracing::{Instrument, debug_span};
+use tracing::{Instrument, info_span};
 use wasmtime::Store;
 use wasmtime_wasi_http::io::TokioIo;
 use wasmtime_wasi_http::p3::WasiHttpView;
@@ -113,6 +113,13 @@ where
         // prepare wasmtime http request and response
         let request = fix_request(request).context("preparing request")?;
 
+        let method = request.method().to_string();
+        let uri = request.uri().to_string();
+        let route = request
+            .uri()
+            .path_and_query()
+            .map_or_else(|| "/".to_string(), |pq| pq.path().to_string());
+
         // instantiate the guest and get the proxy
         let instance_pre = self.state.instance_pre();
         let store_data = self.state.store();
@@ -140,6 +147,7 @@ where
                     let wasi_resp = match service.handle(store, request).await? {
                         Ok(resp) => resp,
                         Err(e) => {
+                            tracing::Span::current().record("http.response.status_code", 500_i64);
                             send_err(sender, anyhow!("guest error: {e}"));
                             return anyhow::Ok(());
                         }
@@ -147,10 +155,14 @@ where
                     let resp = match store.with(|mut store| wasi_resp.into_http(&mut store, io)) {
                         Ok(resp) => resp,
                         Err(e) => {
+                            tracing::Span::current().record("http.response.status_code", 500_i64);
                             send_err(sender, anyhow!("converting guest response: {e}"));
                             return anyhow::Ok(());
                         }
                     };
+
+                    tracing::Span::current()
+                        .record("http.response.status_code", i64::from(resp.status().as_u16()));
 
                     // wrap body so we can detect when hyper finishes consuming it
                     let (body_done_tx, body_done_rx) = oneshot::channel::<()>();
@@ -170,7 +182,14 @@ where
 
                     anyhow::Ok(())
                 })
-                .instrument(debug_span!("http-request"))
+                .instrument(info_span!(
+                    "http-request",
+                    http.request.method = %method,
+                    http.route = %route,
+                    url.full = %uri,
+                    http.response.status_code = tracing::field::Empty,
+                    otel.kind = "server",
+                ))
                 .await;
 
             match result {

--- a/crates/wasi-otel/src/guest/metrics.rs
+++ b/crates/wasi-otel/src/guest/metrics.rs
@@ -57,7 +57,7 @@ impl MetricReader for Reader {
         let mut rm = ResourceMetrics::default();
         self.0.collect(&mut rm)?;
 
-        wit_bindgen::spawn(async move {
+        wit_bindgen::block_on(async move {
             let metrics: wasi::ResourceMetrics = rm.into();
             if let Err(e) = wasi::export(metrics).await {
                 tracing::error!("failed to export metrics: {e}");

--- a/crates/wasi-otel/src/guest/tracing.rs
+++ b/crates/wasi-otel/src/guest/tracing.rs
@@ -57,7 +57,7 @@ impl SpanProcessor for Processor {
             return Ok(());
         }
 
-        wit_bindgen::spawn(async move {
+        wit_bindgen::block_on(async move {
             let spans = spans.into_iter().map(Into::into).collect::<Vec<_>>();
             if let Err(e) = wasi::export(spans).await {
                 tracing::error!("failed to export spans: {e}");

--- a/crates/wasi-otel/src/host/tracing_impl.rs
+++ b/crates/wasi-otel/src/host/tracing_impl.rs
@@ -1,6 +1,6 @@
 //! # WASI Tracing
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::Result;
 use opentelemetry::trace::{self as otel, TraceContextExt};
@@ -26,21 +26,30 @@ impl HostWithStore for WasiOtel {
             return Ok(());
         };
 
-        // set parent span
         let ctx = tracing::Span::current().context();
-        let parent_span = ctx.span();
-        let mut span_data = span_data;
-        for sp in &mut span_data {
-            sp.span_context.trace_id = parent_span.span_context().trace_id().to_string();
-            sp.span_context.is_remote = true;
-            sp.parent_span_id = parent_span.span_context().span_id().to_string();
+        let parent_ctx = ctx.span().span_context().clone();
+
+        if !parent_ctx.is_valid() {
+            tracing::debug!("no valid host span context, dropping guest spans");
+            return Ok(());
         }
 
-        // convert to opentelemetry export format
+        // let batch_ids: HashSet<String> =
+        //     span_data.iter().map(|s| s.span_context.span_id.clone()).collect();
+
+        let mut span_data = span_data;
+        for sp in &mut span_data {
+            sp.span_context.trace_id = parent_ctx.trace_id().to_string();
+            sp.span_context.is_remote = true;
+
+            // if !batch_ids.contains(&sp.parent_span_id) {
+            sp.parent_span_id = parent_ctx.span_id().to_string();
+            // }
+        }
+
         let resource_spans = resource_spans(span_data, resource);
         let export = ExportTraceServiceRequest { resource_spans };
 
-        // export via gRPC
         accessor.with(|mut store| store.get().ctx.export_traces(export)).await?;
 
         Ok(())

--- a/crates/wasi-otel/src/host/tracing_impl.rs
+++ b/crates/wasi-otel/src/host/tracing_impl.rs
@@ -1,6 +1,6 @@
 //! # WASI Tracing
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use anyhow::Result;
 use opentelemetry::trace::{self as otel, TraceContextExt};
@@ -9,6 +9,7 @@ use opentelemetry_proto::tonic::resource::v1::Resource;
 use opentelemetry_proto::tonic::trace::v1::span::{Event, Link};
 use opentelemetry_proto::tonic::trace::v1::status::StatusCode;
 use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span, Status};
+use otel::SpanId;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use wasmtime::component::Accessor;
 
@@ -18,7 +19,7 @@ use crate::{WasiOtel, WasiOtelCtxView};
 
 impl HostWithStore for WasiOtel {
     async fn export<T>(
-        accessor: &Accessor<T, Self>, span_data: Vec<wasi::SpanData>,
+        accessor: &Accessor<T, Self>, mut span_data: Vec<wasi::SpanData>,
     ) -> Result<(), wasi::Error> {
         // return if opentelemetry is not initialized
         let Some(resource) = omnia_otel::init::resource() else {
@@ -28,23 +29,21 @@ impl HostWithStore for WasiOtel {
 
         let ctx = tracing::Span::current().context();
         let parent_ctx = ctx.span().span_context().clone();
-
         if !parent_ctx.is_valid() {
             tracing::debug!("no valid host span context, dropping guest spans");
             return Ok(());
         }
 
-        // let batch_ids: HashSet<String> =
-        //     span_data.iter().map(|s| s.span_context.span_id.clone()).collect();
+        let invalid_id = SpanId::INVALID.to_string();
 
-        let mut span_data = span_data;
         for sp in &mut span_data {
             sp.span_context.trace_id = parent_ctx.trace_id().to_string();
             sp.span_context.is_remote = true;
 
-            // if !batch_ids.contains(&sp.parent_span_id) {
-            sp.parent_span_id = parent_ctx.span_id().to_string();
-            // }
+            // top-level spans need to be parented to the host span
+            if sp.parent_span_id == invalid_id || sp.parent_span_id.is_empty() {
+                sp.parent_span_id = parent_ctx.span_id().to_string();
+            }
         }
 
         let resource_spans = resource_spans(span_data, resource);

--- a/examples/otel/README.md
+++ b/examples/otel/README.md
@@ -22,12 +22,6 @@ cargo run --example otel -- run ./target/wasm32-wasip2/debug/examples/otel_wasm.
 curl --header 'Content-Type: application/json' -d '{"text":"hello"}' http://localhost:8080
 ```
 
-## Cleanup
-
-```bash
-docker compose -f docker/otelcol.yaml down -v
-```
-
 ## Using an OpenTelemetry Collector Backend
 
 To use an OpenTelemetry Collector backend, you need to set the `OTEL_GRPC_URL` environment variable to the
@@ -62,3 +56,12 @@ export OTEL_GRPC_URL="http://localhost:4317"
 export RUST_LOG="info,wasi_otel=debug,omnia_wasi_http=debug,otel=debug"
 cargo run --example otel -- run ./target/wasm32-wasip2/debug/examples/otel_wasm.wasm
 ```
+
+
+
+## Cleanup
+
+```bash
+docker compose -f docker/otelcol.yaml down -v
+```
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes trace export and shutdown behavior in the OTel path; incorrect parenting or blocking shutdown could affect observability or guest teardown timing.
> 
> **Overview**
> Fixes OpenTelemetry instrumentation so host HTTP handling and guest trace export line up correctly in distributed traces.
> 
> The WASI HTTP server now uses an **`info_span!`** for each proxied request with semantic fields (`http.request.method`, `http.route`, `url.full`, `otel.kind = server`) and records **`http.response.status_code`** on success and on guest/conversion failures (500).
> 
> Guest **metrics** and **tracing** shutdown paths switch from **`wit_bindgen::spawn`** to **`wit_bindgen::block_on`** so export to the host finishes before shutdown returns.
> 
> On the host, guest span export no longer overwrites every span’s parent with the current host span: exports are skipped when there is no valid host span context; trace IDs are aligned to the host; only **root** guest spans (empty/invalid parent) are parented to the host span, preserving in-guest parent links.
> 
> The otel example **README** moves the Docker cleanup section to the end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a7ce42a1dfec6df3bdfe110fc36d477945a77f8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->