### PR TITLE
style fenced code

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,17 +21,8 @@ This produces `target/wasm32-wasip2/debug/examples/http_wasm.wasm` (note: the fi
 
 The guest itself is ordinary Rust. It exports a WASI HTTP handler and uses [Axum](https://github.com/tokio-rs/axum) for routing, exactly as you would in a native web service:
 
-```19:27:examples/http/guest.rs
-struct HttpGuest;
-wasip3::http::service::export!(HttpGuest);
-
-impl Guest for HttpGuest {
-    #[omnia_wasi_otel::instrument(name = "http_guest_handle", level = Level::DEBUG)]
-    async fn handle(request: Request) -> Result<Response, ErrorCode> {
-        let router = Router::new().route("/", get(echo_get)).route("/", post(echo_post));
-        omnia_wasi_http::serve(router, request).await
-    }
-}
+```rust
+{{#include ../examples/http/guest.rs:19:27}}
 ```
 
 ## Step 2: Run it in a host
@@ -59,13 +50,8 @@ What just happened: the host linked a WASI HTTP implementation into a wasmtime e
 
 The entire host is one macro invocation. This is the runtime you just ran:
 
-```8:13:examples/http/runtime.rs
-        omnia::runtime!({
-            hosts: {
-                WasiHttp: HttpDefault,
-                WasiOtel: OtelDefault,
-            }
-        });
+```rust
+{{#include ../examples/http/runtime.rs:8:13}}
 ```
 
 Each entry pairs a **WASI host** (the interface guests see, e.g. `WasiKeyValue`) with a **backend** (the implementation behind it, e.g. `KeyValueDefault`, an in-memory cache). The macro generates `main`, connects the backends, links the interfaces, and starts the servers.
@@ -74,14 +60,8 @@ Each entry pairs a **WASI host** (the interface guests see, e.g. `WasiKeyValue`)
 
 The `keyvalue` example adds storage. Its guest opens a bucket and reads/writes keys through the standard `wasi:keyvalue` interface:
 
-```41:47:examples/keyvalue/guest.rs
-async fn handler(body: Bytes) -> HttpResult<Json<Value>> {
-    let bucket = store::open("omnia_bucket".to_string()).await.context("opening bucket")?;
-
-    bucket.set("my_key".to_string(), body.to_vec()).await.context("storing data")?;
-
-    let res = bucket.get("my_key".to_string()).await.context("reading data")?;
-    tracing::debug!("found val: {res:?}");
+```rust
+{{#include ../examples/keyvalue/guest.rs:41:47}}
 ```
 
 Build and run it the same way:

--- a/docs/guides/document-store.md
+++ b/docs/guides/document-store.md
@@ -20,15 +20,8 @@ impl DocumentStore for Provider {}
 
 A `Document` is an id plus raw JSON bytes — serialize your own types into `data`:
 
-```86:93:examples/docstore/guest.rs
-async fn create_stop(Json(req): Json<CreateStopRequest>) -> HttpResult<Json<Value>> {
-    let doc = Document {
-        id: req.id.clone(),
-        data: serde_json::to_vec(&req.stop).context("serializing stop")?,
-    };
-    Provider.insert("stops", &doc).await.context("inserting stop")?;
-    Ok(Json(json!({ "stop": req.stop, "id": req.id })))
-}
+```rust
+{{#include ../../examples/docstore/guest.rs:86:93}}
 ```
 
 The four operations:
@@ -59,75 +52,14 @@ Filters reference fields *inside* the document JSON and compose into trees. Avai
 
 Building a filter from optional query parameters is the common pattern — collect predicates, then `and` them:
 
-```131:165:examples/docstore/guest.rs
-    let mut filters = Vec::new();
-
-    if let Some(q) = &p.q {
-        filters.push(Filter::contains("stop_name", q));
-    }
-    if let Some(zone) = &p.zone {
-        filters.push(Filter::eq("zone_id", zone.as_str()));
-    }
-    if let Some(zone) = &p.exclude_zone {
-        filters.push(Filter::ne("zone_id", zone.as_str()));
-    }
-    if p.accessible.unwrap_or(false) {
-        filters.push(Filter::eq("wheelchair_boarding", 1));
-        filters.push(Filter::is_not_null("zone_id"));
-    }
-    if p.top_level.unwrap_or(false) {
-        filters.push(Filter::is_null("parent_station"));
-    }
-    if let Some(v) = p.min_lat {
-        filters.push(Filter::gte("stop_lat", v));
-    }
-    if let Some(v) = p.max_lat {
-        filters.push(Filter::lte("stop_lat", v));
-    }
-    if let Some(v) = p.min_lon {
-        filters.push(Filter::gte("stop_lon", v));
-    }
-    if let Some(v) = p.max_lon {
-        filters.push(Filter::lte("stop_lon", v));
-    }
-    if let Some(date) = &p.updated_on {
-        filters.push(Filter::on_date("last_updated", date)?);
-    }
-
-    let filter = if filters.is_empty() { None } else { Some(Filter::and(filters)) };
+```rust
+{{#include ../../examples/docstore/guest.rs:131:165}}
 ```
 
 Nested composition — OR across fields, and negated conjunctions:
 
-```244:271:examples/docstore/guest.rs
-    if let Some(q) = &p.q {
-        filters.push(Filter::or([
-            Filter::contains("route_short_name", q),
-            Filter::contains("route_long_name", q),
-        ]));
-    }
-    if let Some(types_str) = &p.types {
-        let type_vals: Vec<ScalarValue> = types_str
-            .split(',')
-            .filter_map(|s| s.trim().parse::<i32>().ok())
-            .map(ScalarValue::from)
-            .collect();
-        if !type_vals.is_empty() {
-            filters.push(Filter::in_list("route_type", type_vals));
-        }
-    }
-    if let Some(agency) = &p.agency {
-        filters.push(Filter::eq("agency_id", agency.as_str()));
-    }
-    if let Some(exclude) = p.exclude_type {
-        filters.push(Filter::negate(Filter::eq("route_type", exclude)));
-    }
-    if let (Some(agency), Some(rtype)) = (&p.not_agency, p.not_type) {
-        filters.push(Filter::negate(Filter::and([
-            Filter::eq("agency_id", agency.as_str()),
-            Filter::eq("route_type", rtype),
-        ])));
-    }
+```rust
+{{#include ../../examples/docstore/guest.rs:244:271}}
 ```
 
 The backend translates the tree to its native query language (PoloDB queries, OData `$filter` for Azure Table), so a filter that works locally works in production.
@@ -136,26 +68,8 @@ The backend translates the tree to its native query language (PoloDB queries, OD
 
 `query(collection, QueryOptions)` combines the filter with sorting and cursor pagination:
 
-```167:185:examples/docstore/guest.rs
-    let result = Provider
-        .query(
-            "stops",
-            QueryOptions {
-                filter,
-                order_by: vec![SortField {
-                    field: "stop_name".into(),
-                    descending: false,
-                }],
-                limit: p.limit,
-                continuation: p.continuation,
-                ..Default::default()
-            },
-        )
-        .await
-        .context("querying stops")?;
-
-    let stops = deserialize_docs(&result.documents)?;
-    Ok(Json(json!({ "stops": stops, "continuation": result.continuation })))
+```rust
+{{#include ../../examples/docstore/guest.rs:167:185}}
 ```
 
 The result carries `documents` plus an opaque `continuation` token when more pages exist; hand the token back in the next query's `continuation` to resume. Treat it as opaque — its format is backend-specific.

--- a/docs/guides/messaging.md
+++ b/docs/guides/messaging.md
@@ -26,18 +26,8 @@ Metadata and content type travel with the message; on Kafka, `add_metadata("key"
 
 Messaging is a **trigger**: the host (`WasiMessaging`) subscribes to topics and delivers each message to the guest's exported handler, instantiating a fresh guest instance per message:
 
-```86:96:examples/messaging/guest.rs
-pub struct Messaging;
-omnia_wasi_messaging::export!(Messaging with_types_in omnia_wasi_messaging);
-
-impl omnia_wasi_messaging::incoming_handler::Guest for Messaging {
-    async fn handle(message: Message) -> anyhow::Result<(), Error> {
-        tracing::debug!("start processing msg");
-
-        let topic = message.topic().unwrap_or_default();
-        tracing::debug!("message received for: {topic}");
-
-        match topic.as_str() {
+```rust
+{{#include ../../examples/messaging/guest.rs:86:96}}
 ```
 
 Dispatch on `message.topic()`. Which topics the host subscribes to is backend configuration (`KAFKA_TOPICS`, `NATS_TOPICS`; the in-memory default delivers everything published in-process). In multi-guest deployments, `[[route.messaging]]` entries select the target guest by NATS-style topic pattern — see [Multi-Guest Deployments](multi-guest-deployments.md#routing-inbound-traffic).

--- a/docs/guides/model-completions.md
+++ b/docs/guides/model-completions.md
@@ -8,36 +8,8 @@ This page covers the guest API, the grants model, the available backends, and ho
 
 A model guest is typically a command-mode guest (see [Writing Guests](writing-guests.md#command-mode-guests)). It builds a `Request` and calls `completion::create`:
 
-```35:63:examples/model/guest.rs
-        let (system, messages) = Sections {
-            role: Some("a terse code reviewer".to_string()),
-            task: "decide whether the change is acceptable".to_string(),
-            context: Some("the diff adds a bounds check".to_string()),
-            ..Sections::default()
-        }
-        .channels(None);
-
-        let request = completion::Request {
-            model: None,
-            system,
-            messages,
-            generation: None,
-            format: completion::Format::Schema(completion::Schema {
-                name: "verdict".to_string(),
-                schema: "{\"type\":\"object\"}".to_string(),
-            }),
-            tools: vec![],
-            grants: completion::Grants {
-                references: Some("shelf".to_string()),
-                workspace,
-                verify: vec![],
-            },
-        };
-
-        let answer = match completion::create(request).await {
-            Ok(reply) => reply.answer,
-            Err(error) => format!("error: {error:?}"),
-        };
+```rust
+{{#include ../../examples/model/guest.rs:35:63}}
 ```
 
 The pieces:
@@ -105,15 +77,8 @@ The end-to-end demo lives at [`backends/examples/cursor`](https://github.com/aug
 
 Guests can also sit on the other side of the protocol: exposing tools and resources to model backends as a stateless MCP server over HTTP. Implement `omnia_guest::mcp::McpServer` and serve `mcp::router` from the guest's HTTP handler:
 
-```18:25:examples/mcp/guest.rs
-struct HttpGuest;
-wasip3::http::service::export!(HttpGuest);
-
-impl Guest for HttpGuest {
-    async fn handle(request: Request) -> Result<Response, ErrorCode> {
-        omnia_wasi_http::serve(mcp::router(Docs), request).await
-    }
-}
+```rust
+{{#include ../../examples/mcp/guest.rs:18:25}}
 ```
 
 The `McpServer` trait has five methods: `info` (server identity), `tools` (tool declarations with JSON Schema inputs), `call_tool`, and optionally `resources`/`read_resource`. The router handles the JSON-RPC and Streamable HTTP transport details.

--- a/docs/guides/sql-and-orm.md
+++ b/docs/guides/sql-and-orm.md
@@ -8,27 +8,8 @@ The [`sql`](../../examples/sql/) example is a complete CRUD service (agencies an
 
 Open a connection by pool name, prepare a statement, and execute it. Use this level for DDL and anything the builders don't cover:
 
-```376:395:examples/sql/guest.rs
-    let pool = Connection::open("db".to_string())
-        .await
-        .map_err(|e| anyhow!("failed to open connection: {}", e.trace()))?;
-
-    // Create agency table
-    let create_agency = "CREATE TABLE IF NOT EXISTS agency (
-        agency_id INTEGER PRIMARY KEY,
-        name TEXT NOT NULL,
-        url TEXT,
-        timezone TEXT,
-        created_at TEXT NOT NULL
-    )";
-
-    let stmt = Statement::prepare(create_agency.to_string(), vec![])
-        .await
-        .map_err(|e| anyhow!("failed to prepare agency table creation: {}", e.trace()))?;
-
-    readwrite::exec(&pool, &stmt)
-        .await
-        .map_err(|e| anyhow!("agency table creation failed: {}", e.trace()))?;
+```rust
+{{#include ../../examples/sql/guest.rs:376:395}}
 ```
 
 Statements are always parameterized (`$1`, `$2`, ...) — string interpolation into SQL is never necessary and never safe.
@@ -41,18 +22,8 @@ The pool name (`"db"` here) is what the backend resolves: the SQLite default ign
 
 The `entity!` macro maps a struct to a table and generates column metadata plus a `from_row` constructor:
 
-```419:429:examples/sql/guest.rs
-entity!(
-    table = "agency",
-    #[derive(Debug, Clone, Serialize)]
-    pub struct Agency {
-        pub agency_id: i64,
-        pub name: String,
-        pub url: Option<String>,
-        pub timezone: Option<String>,
-        pub created_at: String,
-    }
-);
+```rust
+{{#include ../../examples/sql/guest.rs:419:429}}
 ```
 
 `Option<T>` fields map to nullable columns. The struct is otherwise a normal struct — derive whatever you need.
@@ -88,67 +59,22 @@ Provider.exec("db".to_string(), query.sql, query.params).await?;
 
 Update only the fields that changed, guarded by a filter:
 
-```183:198:examples/sql/guest.rs
-    let mut update = UpdateBuilder::<Agency>::new();
-
-    if let Some(name) = req.name {
-        update = update.set("name", name);
-    }
-    if let Some(url) = req.url {
-        update = update.set("url", url);
-    }
-    if let Some(timezone) = req.timezone {
-        update = update.set("timezone", timezone);
-    }
-
-    let query = update
-        .r#where(Filter::eq("agency_id", id))
-        .build()
-        .context("failed to build update query")?;
+```rust
+{{#include ../../examples/sql/guest.rs:183:198}}
 ```
 
 Delete, checking the affected-row count for a not-found result:
 
-```356:368:examples/sql/guest.rs
-    let query = DeleteBuilder::<Feed>::new()
-        .r#where(Filter::eq("feed_id", id))
-        .build()
-        .context("failed to build delete query")?;
-
-    let rows_affected = Provider
-        .exec("db".to_string(), query.sql, query.params)
-        .await
-        .context("failed to delete feed")?;
-
-    if rows_affected == 0 {
-        return Err(anyhow!("feed not found").into());
-    }
+```rust
+{{#include ../../examples/sql/guest.rs:356:368}}
 ```
 
 ## Joins
 
 An entity can span a JOIN. Fields not listed in `columns` resolve against the main table; listed ones pull from the joined table under an alias:
 
-```445:463:examples/sql/guest.rs
-entity!(
-    table = "feed",
-    columns = [
-        ("agency", "name", "agency_name"),
-        ("agency", "url", "agency_url"),
-        ("agency", "timezone", "agency_timezone"),
-    ],
-    joins = [Join::left("agency", Filter::col_eq("feed", "agency_id", "agency", "agency_id")),],
-    #[derive(Debug, Clone, Serialize)]
-    pub struct FeedWithAgency {
-        pub feed_id: i64,                    // Auto: feed.feed_id
-        pub agency_id: i64,                  // Auto: feed.agency_id
-        pub description: String,             // Auto: feed.description
-        pub created_at: String,              // Auto: feed.created_at
-        pub agency_name: String,             // Manual: agency.name AS agency_name
-        pub agency_url: Option<String>,      // Manual: agency.url AS agency_url
-        pub agency_timezone: Option<String>, // Manual: agency.timezone AS agency_timezone
-    }
-);
+```rust
+{{#include ../../examples/sql/guest.rs:445:463}}
 ```
 
 Selecting `FeedWithAgency` then works exactly like a single-table entity — `order_by_desc(Some("feed"), "created_at")` qualifies the table when the column name is ambiguous.

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -35,85 +35,20 @@ The `wasi:keyvalue` seam test is the exemplar. It assembles the same runtime the
 
 **1. A backend bundle with accessor impls** (mirroring the macro's generated `Backends`):
 
-```27:50:crates/wasi-keyvalue/tests/seam.rs
-#[derive(Clone)]
-struct Bundle {
-    http: HttpDefault,
-    otel: OtelDefault,
-    keyvalue: KeyValueDefault,
-}
-
-impl HasHttp for Bundle {
-    fn http_view<'a>(&'a mut self, table: &'a mut ResourceTable) -> WasiHttpCtxView<'a> {
-        self.http.as_view(table)
-    }
-}
-
-impl HasOtel for Bundle {
-    fn otel_ctx(&mut self) -> &mut dyn WasiOtelCtx {
-        &mut self.otel
-    }
-}
-
-impl HasKeyValue for Bundle {
-    fn keyvalue_ctx(&mut self) -> &mut dyn WasiKeyValueCtx {
-        &mut self.keyvalue
-    }
-}
+```rust
+{{#include ../../crates/wasi-keyvalue/tests/seam.rs:27:50}}
 ```
 
 **2. Build the runtime over the guest**, keeping a clone of the backend as a probe (the in-memory defaults share state across clones):
 
-```55:80:crates/wasi-keyvalue/tests/seam.rs
-async fn runtime() -> Result<Option<(Runtime<Bundle>, KeyValueDefault)>> {
-    let Some(wasm) = find_guest("keyvalue_wasm.wasm") else {
-        return Ok(None);
-    };
-
-    let bundle = Bundle {
-        http: HttpDefault::connect().await.context("connecting http")?,
-        otel: OtelDefault::connect().await.context("connecting otel")?,
-        keyvalue: KeyValueDefault::connect().await.context("connecting keyvalue")?,
-    };
-    let store_probe = bundle.keyvalue.clone();
-
-    let mut deployment =
-        DeploymentBuilder::new().wasm(wasm).build::<StoreCtx<Bundle>>().await.context("build")?;
-    deployment.host::<WasiHttp, Bundle>().context("link http")?;
-    deployment.host::<WasiOtel, Bundle>().context("link otel")?;
-    deployment.host::<WasiKeyValue, Bundle>().context("link keyvalue")?;
-    let registry = deployment.into_registry().context("assemble registry")?;
-
-    let runtime = Runtime::from_parts(
-        Arc::new(registry),
-        Vec::new(),
-        Arc::new(MountRegistry::default()),
-        bundle,
-    );
-    Ok(Some((runtime, store_probe)))
-}
+```rust
+{{#include ../../crates/wasi-keyvalue/tests/seam.rs:55:80}}
 ```
 
 **3. Drive the guest and assert both sides of the seam** — the guest's response *and* the effect that landed in the host backend:
 
-```83:99:crates/wasi-keyvalue/tests/seam.rs
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn set_then_get() -> Result<()> {
-    let Some((runtime, store)) = runtime().await? else {
-        return Ok(());
-    };
-
-    let response = http::post(&runtime, "/", "payload-value").await?;
-    assert!(response.status().is_success(), "guest completes the keyvalue round-trip");
-
-    // The guest stored the request body under `my_key` in `omnia_bucket`; the
-    // shared backend must now hold that write.
-    let bucket = store.open_bucket("omnia_bucket".to_owned()).await.context("open bucket")?;
-    let stored = bucket.get("my_key".to_owned()).await.context("read my_key")?;
-    assert_eq!(stored.as_deref(), Some(b"payload-value".as_slice()), "the write reached the host");
-
-    Ok(())
-}
+```rust
+{{#include ../../crates/wasi-keyvalue/tests/seam.rs:83:99}}
 ```
 
 That second assertion is the point: a `200` proves the call crossed the WIT boundary without trapping; reading the shared backend proves the write actually happened host-side rather than being swallowed.

--- a/docs/guides/writing-guests.md
+++ b/docs/guides/writing-guests.md
@@ -27,17 +27,8 @@ cargo build --example <name>-wasm --target wasm32-wasip2
 
 Export the WASI HTTP handler and hand routing to [Axum](https://github.com/tokio-rs/axum) via `omnia_wasi_http::serve`:
 
-```19:27:examples/http/guest.rs
-struct HttpGuest;
-wasip3::http::service::export!(HttpGuest);
-
-impl Guest for HttpGuest {
-    #[omnia_wasi_otel::instrument(name = "http_guest_handle", level = Level::DEBUG)]
-    async fn handle(request: Request) -> Result<Response, ErrorCode> {
-        let router = Router::new().route("/", get(echo_get)).route("/", post(echo_post));
-        omnia_wasi_http::serve(router, request).await
-    }
-}
+```rust
+{{#include ../../examples/http/guest.rs:19:27}}
 ```
 
 Handlers are ordinary Axum handlers. Return `omnia_guest::HttpResult<T>` to map errors to HTTP responses; `anyhow::Context` works as usual.
@@ -50,12 +41,8 @@ Each capability is a module in its `omnia-wasi-*` crate. The guest never names a
 
 Key-value (`wasi:keyvalue`):
 
-```42:46:examples/keyvalue/guest.rs
-    let bucket = store::open("omnia_bucket".to_string()).await.context("opening bucket")?;
-
-    bucket.set("my_key".to_string(), body.to_vec()).await.context("storing data")?;
-
-    let res = bucket.get("my_key".to_string()).await.context("reading data")?;
+```rust
+{{#include ../../examples/keyvalue/guest.rs:42:46}}
 ```
 
 Publishing a message (`wasi:messaging`):
@@ -85,18 +72,8 @@ The other capabilities follow the same shape; each has a full example:
 
 A guest can export a messaging handler alongside (or instead of) an HTTP handler. The host's messaging trigger delivers each subscribed message to it:
 
-```86:96:examples/messaging/guest.rs
-pub struct Messaging;
-omnia_wasi_messaging::export!(Messaging with_types_in omnia_wasi_messaging);
-
-impl omnia_wasi_messaging::incoming_handler::Guest for Messaging {
-    async fn handle(message: Message) -> anyhow::Result<(), Error> {
-        tracing::debug!("start processing msg");
-
-        let topic = message.topic().unwrap_or_default();
-        tracing::debug!("message received for: {topic}");
-
-        match topic.as_str() {
+```rust
+{{#include ../../examples/messaging/guest.rs:86:96}}
 ```
 
 `examples/messaging` demonstrates pub-sub, request-reply, and fan-out with the in-memory default backend; the same guest works against Kafka or NATS.
@@ -105,17 +82,8 @@ impl omnia_wasi_messaging::incoming_handler::Guest for Messaging {
 
 For run-once workloads (jobs, CLIs, agent tasks), export `wasi:cli/run` instead of an HTTP handler. The host drives `run` exactly once and exits with its status:
 
-```28:37:examples/cli/guest.rs
-use wasip3::exports::cli::run::Guest;
-
-struct Cli;
-wasip3::cli::command::export!(Cli);
-
-impl Guest for Cli {
-    /// The `wasi:cli/run` export: dispatch on argv, then signal success or a
-    /// process exit code.
-    async fn run() -> Result<(), ()> {
-        let args: Vec<String> = std::env::args().collect();
+```rust
+{{#include ../../examples/cli/guest.rs:28:37}}
 ```
 
 - Arguments after `--` on the host command line arrive as the guest's argv (`args[0]` is the program name, supplied by the runtime).

--- a/docs/reference/model.md
+++ b/docs/reference/model.md
@@ -84,37 +84,8 @@ From the grants, the host — never the guest or backend — merges these tools 
 
 ### File shape
 
-```1:30:examples/model/fixtures/4855dccaa38b7e6d.json
-{
-  "key_request": {
-    "model": null,
-    "system": "a terse code reviewer",
-    "messages": [
-      {
-        "role": "user",
-        "content": "decide whether the change is acceptable\n\nthe diff adds a bounds check"
-      }
-    ],
-    "generation": null,
-    "format": {
-      "kind": "schema",
-      "schema": {
-        "name": "verdict",
-        "schema": "{\"type\":\"object\"}"
-      }
-    },
-    "tools": [],
-    "grants": {
-      "references": "shelf",
-      "verify": []
-    }
-  },
-  "answer": {
-    "verdict": "pass",
-    "reason": "the bounds check is correct"
-  },
-  "transcript": null
-}
+```json
+{{#include ../../examples/model/fixtures/4855dccaa38b7e6d.json:1:30}}
 ```
 
 | Field | Required | Meaning |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Markdown-only change; no runtime or API behavior. Risk is limited to doc build/render if include paths or line numbers are wrong.
> 
> **Overview**
> **Documentation snippets now pull from source files** instead of pasting Rust/JSON inline.
> 
> Across `docs/getting-started.md`, several guides (`document-store`, `messaging`, `model-completions`, `sql-and-orm`, `testing`, `writing-guests`), and `docs/reference/model.md`, fenced blocks that duplicated example or test code are replaced with normal ` ```rust ` / ` ```json ` fences containing **`{{#include <path>:<start>:<end>}}`** (mdBook-style line ranges). The prior custom fence headers like ` ```19:27:examples/http/guest.rs ` go away.
> 
> **Effect:** rendered docs should show the same examples, but the quoted lines stay aligned with `examples/` and `crates/.../tests/` when those files change—no manual copy-paste in markdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 190a1f17b26ae801c17828db292b558e4fe25a75. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->