### PR TITLE
MCP grants

### DIFF
--- a/crates/host-macros/README.md
+++ b/crates/host-macros/README.md
@@ -39,6 +39,7 @@ Each key is a **host type** from a `omnia-wasi-*` crate (`WasiHttp`, `WasiKeyVal
 ```rust,ignore
 omnia::runtime!({
     mode: server,          // optional: `server` (default) or `command`
+    config: concat!(env!("CARGO_MANIFEST_DIR"), "/omnia.toml"),  // optional default manifest
     hosts: {
         HostType: BackendType,
         // ...
@@ -48,6 +49,7 @@ omnia::runtime!({
 
 - **`mode: server`** — trigger hosts (`WasiHttp`, `WasiMessaging`, `WasiWebSocket`) run servers and drive guests per request.
 - **`mode: command`** — the runtime drives the guest's `wasi:cli/run` export once and exits with its status. A backend-less command runtime is valid: `omnia::runtime!({ mode: command });`
+- **`config:`** — a path expression compiled into the generated `main` as the default manifest, used only when the command line supplies no positional wasm, `--config`, or `OMNIA_CONFIG`. Anchor it with `env!("CARGO_MANIFEST_DIR")` to make it absolute at compile time.
 
 ## Generated Code
 

--- a/crates/host-macros/src/runtime.rs
+++ b/crates/host-macros/src/runtime.rs
@@ -19,6 +19,7 @@ pub fn expand(config: &Config) -> TokenStream {
         server_types,
         backends_ty,
         backends_def,
+        config_file,
     } = Codegen::from(config);
 
     let mode = match mode {
@@ -61,7 +62,7 @@ pub fn expand(config: &Config) -> TokenStream {
             /// deployment through this runtime's hosts and backends.
             #[tokio::main]
             pub async fn main() -> ::std::process::ExitCode {
-                omnia::main::<#backends_ty, Hooks>(#mode).await
+                omnia::main::<#backends_ty, Hooks>(#mode, #config_file).await
             }
 
             /// Drive one deployment through this runtime's hosts and backends,
@@ -106,6 +107,16 @@ mod tests {
     fn expand_command() {
         insta::assert_snapshot!(expand_pretty(quote!({
             mode: command,
+            hosts: {
+                WasiOtel: OtelDefault,
+            },
+        })));
+    }
+
+    #[test]
+    fn expand_config_file() {
+        insta::assert_snapshot!(expand_pretty(quote!({
+            config: concat!(env!("CARGO_MANIFEST_DIR"), "/omnia.toml"),
             hosts: {
                 WasiOtel: OtelDefault,
             },

--- a/crates/host-macros/src/runtime/codegen.rs
+++ b/crates/host-macros/src/runtime/codegen.rs
@@ -15,6 +15,7 @@ pub struct Codegen {
     pub server_types: Vec<Path>,
     pub backends_ty: TokenStream,
     pub backends_def: TokenStream,
+    pub config_file: TokenStream,
 }
 
 impl From<&Config> for Codegen {
@@ -26,12 +27,18 @@ impl From<&Config> for Codegen {
 
         let (backends_ty, backends_def) = emit_backends(host_entries);
 
+        let config_file = config.config_file.as_ref().map_or_else(
+            || quote! { ::std::option::Option::None },
+            |expr| quote! { ::std::option::Option::Some(::std::path::PathBuf::from(#expr)) },
+        );
+
         Self {
             mode: config.mode,
             host_types,
             server_types,
             backends_ty,
             backends_def,
+            config_file,
         }
     }
 }

--- a/crates/host-macros/src/runtime/parse.rs
+++ b/crates/host-macros/src/runtime/parse.rs
@@ -4,7 +4,7 @@
 
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
-use syn::{Ident, Path, Result, Token};
+use syn::{Expr, Ident, Path, Result, Token};
 
 /// Deployment drive mode parsed from `runtime!({ ... })`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -18,6 +18,8 @@ pub enum Mode {
 pub struct Config {
     pub mode: Mode,
     pub host_entries: Vec<HostEntry>,
+    #[allow(clippy::struct_field_names)]
+    pub config_file: Option<Expr>,
 }
 
 /// One `Host: Backend` wiring from the `hosts: { ... }` block.
@@ -30,6 +32,7 @@ impl Parse for Config {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let mut mode = Mode::default();
         let mut host_entries = Vec::new();
+        let mut config_file = None;
 
         let settings;
         syn::braced!(settings in input);
@@ -39,21 +42,28 @@ impl Parse for Config {
             match setting.into_value() {
                 Opt::Mode(m) => mode = m,
                 Opt::Hosts(h) => host_entries = h,
+                Opt::Config(c) => config_file = Some(c),
             }
         }
 
-        Ok(Self { mode, host_entries })
+        Ok(Self {
+            mode,
+            host_entries,
+            config_file,
+        })
     }
 }
 
 mod kw {
     syn::custom_keyword!(mode);
     syn::custom_keyword!(hosts);
+    syn::custom_keyword!(config);
 }
 
 enum Opt {
     Mode(Mode),
     Hosts(Vec<HostEntry>),
+    Config(Expr),
 }
 
 impl Parse for Opt {
@@ -69,6 +79,10 @@ impl Parse for Opt {
             let list;
             syn::braced!(list in input);
             Ok(Self::Hosts(parse_host_entries(&list)?))
+        } else if l.peek(kw::config) {
+            input.parse::<kw::config>()?;
+            input.parse::<Token![:]>()?;
+            Ok(Self::Config(input.parse()?))
         } else {
             Err(l.error())
         }

--- a/crates/host-macros/src/snapshots/omnia_host_macros__runtime__tests__expand_command.snap
+++ b/crates/host-macros/src/snapshots/omnia_host_macros__runtime__tests__expand_command.snap
@@ -44,7 +44,8 @@ mod runtime {
     /// deployment through this runtime's hosts and backends.
     #[tokio::main]
     pub async fn main() -> ::std::process::ExitCode {
-        omnia::main::<Backends, Hooks>(omnia::Mode::Command).await
+        omnia::main::<Backends, Hooks>(omnia::Mode::Command, ::std::option::Option::None)
+            .await
     }
     /// Drive one deployment through this runtime's hosts and backends,
     /// blocking until the guest completes.

--- a/crates/host-macros/src/snapshots/omnia_host_macros__runtime__tests__expand_config_file.snap
+++ b/crates/host-macros/src/snapshots/omnia_host_macros__runtime__tests__expand_config_file.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/host-macros/src/runtime.rs
-expression: "expand_pretty(quote!({\n    hosts:\n    {\n        WasiHttp: HttpDefault, WasiOtel: OtelDefault, WasiKeyValue:\n        KeyValueDefault,\n    },\n}))"
+assertion_line: 118
+expression: "expand_pretty(quote!({\n    config: concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/omnia.toml\"), hosts:\n    { WasiOtel: OtelDefault, },\n}))"
 ---
 mod runtime {
     use anyhow::Result;
@@ -11,29 +12,14 @@ mod runtime {
     use omnia::Backend;
     #[derive(Clone)]
     struct Backends {
-        http_default: HttpDefault,
         otel_default: OtelDefault,
-        key_value_default: KeyValueDefault,
     }
     impl omnia::Backends for Backends {
         async fn connect() -> Result<Self> {
-            let (http_default, otel_default, key_value_default) = tokio::try_join!(
-                < HttpDefault as Backend > ::connect(), < OtelDefault as Backend >
-                ::connect(), < KeyValueDefault as Backend > ::connect(),
+            let (otel_default,) = tokio::try_join!(
+                < OtelDefault as Backend > ::connect(),
             )?;
-            Ok(Self {
-                http_default,
-                otel_default,
-                key_value_default,
-            })
-        }
-    }
-    impl omnia::HasHttp for Backends {
-        fn http_view<'a>(
-            &'a mut self,
-            table: &'a mut omnia::wasmtime_wasi::ResourceTable,
-        ) -> omnia_wasi_http::WasiHttpCtxView<'a> {
-            self.http_default.as_view(table)
+            Ok(Self { otel_default })
         }
     }
     impl omnia_wasi_otel::HasOtel for Backends {
@@ -41,25 +27,16 @@ mod runtime {
             &mut self.otel_default
         }
     }
-    impl omnia_wasi_keyvalue::HasKeyValue for Backends {
-        fn keyvalue_ctx(&mut self) -> &mut dyn omnia_wasi_keyvalue::WasiKeyValueCtx {
-            &mut self.key_value_default
-        }
-    }
     struct Hooks;
     impl omnia::Wiring<Backends> for Hooks {
         fn link(
             deployment: &mut omnia::Deployment<omnia::StoreCtx<Backends>>,
         ) -> Result<()> {
-            deployment.host::<WasiHttp, Backends>()?;
             deployment.host::<WasiOtel, Backends>()?;
-            deployment.host::<WasiKeyValue, Backends>()?;
             Ok(())
         }
         async fn serve(runtime: &omnia::Runtime<Backends>) -> Result<()> {
-            let servers: Vec<future::BoxFuture<'_, Result<()>>> = vec![
-                Box::pin(WasiHttp.run(runtime)),
-            ];
+            let servers: Vec<future::BoxFuture<'_, Result<()>>> = vec![];
             future::try_join_all(servers).await?;
             Ok(())
         }
@@ -68,7 +45,17 @@ mod runtime {
     /// deployment through this runtime's hosts and backends.
     #[tokio::main]
     pub async fn main() -> ::std::process::ExitCode {
-        omnia::main::<Backends, Hooks>(omnia::Mode::Server, ::std::option::Option::None)
+        omnia::main::<
+            Backends,
+            Hooks,
+        >(
+                omnia::Mode::Server,
+                ::std::option::Option::Some(
+                    ::std::path::PathBuf::from(
+                        concat!(env!("CARGO_MANIFEST_DIR"), "/omnia.toml"),
+                    ),
+                ),
+            )
             .await
     }
     /// Drive one deployment through this runtime's hosts and backends,

--- a/crates/host-macros/tests/compile_fail/unknown_key.stderr
+++ b/crates/host-macros/tests/compile_fail/unknown_key.stderr
@@ -1,4 +1,4 @@
-error: expected `mode` or `hosts`
+error: expected one of: `mode`, `hosts`, `config`
  --> tests/compile_fail/unknown_key.rs:2:5
   |
 2 |     guests: {},

--- a/crates/omnia/src/deployment.rs
+++ b/crates/omnia/src/deployment.rs
@@ -27,7 +27,8 @@ use crate::{Host, Mode, RuntimeOptions, Server, Telemetry};
 ///
 /// The single-file shorthand ([`wasm`]) and the manifest-driven deployment
 /// ([`config`]) are both expressed here; [`build`] resolves whichever is set —
-/// falling back to the `OMNIA_CONFIG` environment variable for the manifest.
+/// falling back to the `OMNIA_CONFIG` environment variable, then to the
+/// compiled-in [`default_config`](Self::default_config) manifest.
 ///
 /// ```ignore
 /// let deployment = DeploymentBuilder::new()
@@ -46,6 +47,7 @@ use crate::{Host, Mode, RuntimeOptions, Server, Telemetry};
 pub struct DeploymentBuilder {
     wasm: Option<PathBuf>,
     config: Option<PathBuf>,
+    default_config: Option<PathBuf>,
     args: Vec<String>,
     mode: Mode,
     mounts: Vec<Mount>,
@@ -71,6 +73,15 @@ impl DeploymentBuilder {
     #[must_use]
     pub fn config(mut self, config: impl Into<Option<PathBuf>>) -> Self {
         self.config = config.into();
+        self
+    }
+
+    /// Set a fallback manifest path — typically compiled in via the `runtime!`
+    /// macro's `config:` field — used only when no explicit `config`,
+    /// `OMNIA_CONFIG`, or `wasm` source is given.
+    #[must_use]
+    pub fn default_config(mut self, config: impl Into<Option<PathBuf>>) -> Self {
+        self.default_config = config.into();
         self
     }
 
@@ -108,17 +119,20 @@ impl DeploymentBuilder {
     /// Resolve the configured source into a [`Deployment`], choosing single-file
     /// or manifest-driven population.
     ///
-    /// Resolution: a `config` path (set via [`config`](Self::config) or the
-    /// `OMNIA_CONFIG` environment variable) selects a manifest-driven deployment;
-    /// otherwise the `wasm` path is the one-guest shorthand. At least one of the
-    /// two must be provided.
+    /// Resolution order: a `config` path (set via [`config`](Self::config)),
+    /// the `OMNIA_CONFIG` environment variable, the `wasm` one-guest shorthand,
+    /// then the [`default_config`](Self::default_config) fallback. At least one
+    /// must be provided.
     ///
     /// # Errors
     ///
-    /// Returns an error if neither a config nor a wasm path is available, or if
-    /// the selected source cannot be built.
+    /// Returns an error if no source resolves, or if the selected source cannot
+    /// be built.
     pub async fn build<T: WasiView + 'static>(self) -> Result<Deployment<T>> {
-        let manifest = self.config.or_else(|| env::var_os("OMNIA_CONFIG").map(PathBuf::from));
+        let manifest = self
+            .config
+            .or_else(|| env::var_os("OMNIA_CONFIG").map(PathBuf::from))
+            .or_else(|| if self.wasm.is_some() { None } else { self.default_config });
 
         // CLI `--mount`/`--link` resolve against the process working directory
         // and layer on top of whatever the selected source provides.

--- a/crates/omnia/src/runtime.rs
+++ b/crates/omnia/src/runtime.rs
@@ -78,8 +78,12 @@ pub trait Wiring<B: Backends> {
 }
 
 /// CLI entry point for generated `main` functions.
+///
+/// `default_config` is the runtime's compiled-in manifest fallback (the
+/// `runtime!` macro's `config:` field), used only when the CLI supplies no
+/// source.
 #[doc(hidden)]
-pub async fn main<B, H>(mode: Mode) -> ExitCode
+pub async fn main<B, H>(mode: Mode, default_config: Option<std::path::PathBuf>) -> ExitCode
 where
     B: Backends,
     H: Wiring<B>,
@@ -95,6 +99,7 @@ where
             let builder = DeploymentBuilder::new()
                 .wasm(wasm)
                 .config(config)
+                .default_config(default_config)
                 .args(args)
                 .mounts(mounts)
                 .links(links)

--- a/crates/testkit/src/model.rs
+++ b/crates/testkit/src/model.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use anyhow::anyhow;
 use futures::FutureExt as _;
-use omnia_guest::model::{Error, Model, Reply, Request, Usage};
+use omnia_guest::model::{Error, McpGrant, Model, Reply, Request, Tool, Usage};
 use omnia_wasi_model::{Answer, FutureResult, ToolHost, WasiModelCtx};
 use serde_json::Value;
 
@@ -139,6 +139,80 @@ fn answer_reply(answer: Answer) -> Reply {
             reasoning_tokens: usage.reasoning_tokens,
         }),
     }
+}
+
+/// A model decorator that records requests before delegating them, so
+/// tests can assert on prompt assembly, formats, and tool grants.
+#[derive(Clone, Debug)]
+pub struct Harness<B> {
+    backend: B,
+    requests: Arc<Mutex<Vec<Request>>>,
+}
+
+impl<B> Harness<B> {
+    /// Wrap `backend` with request recording.
+    #[must_use]
+    pub fn new(backend: B) -> Self {
+        Self {
+            backend,
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Return a thread-safe snapshot of every request in call order.
+    #[must_use]
+    pub fn requests(&self) -> Vec<Request> {
+        lock(&self.requests).clone()
+    }
+}
+
+impl Harness<Scripted> {
+    /// Build a recorded harness from ordered completion results.
+    #[must_use]
+    pub fn scripted(responses: impl IntoIterator<Item = Result<Reply, Error>>) -> Self {
+        Self::new(Scripted::new(responses))
+    }
+
+    /// Build a recorded harness from ordered answer strings.
+    #[must_use]
+    pub fn answering<S>(answers: impl IntoIterator<Item = S>) -> Self
+    where
+        S: Into<String>,
+    {
+        Self::new(Scripted::answers(answers))
+    }
+
+    /// Assert that every scripted result was consumed.
+    ///
+    /// # Panics
+    ///
+    /// Panics when one or more results remain.
+    pub fn assert_exhausted(&self) {
+        self.backend.assert_exhausted();
+    }
+}
+
+impl<B> Model for Harness<B>
+where
+    B: Model,
+{
+    fn create(&self, request: Request) -> impl Future<Output = Result<Reply, Error>> + Send {
+        lock(&self.requests).push(request.clone());
+        self.backend.create(request)
+    }
+}
+
+/// Return the MCP grants carried by a request.
+#[must_use]
+pub fn mcp_grants(request: &Request) -> Vec<&McpGrant> {
+    request
+        .tools
+        .iter()
+        .filter_map(|tool| match tool {
+            Tool::Mcp(grant) => Some(grant),
+            Tool::Function(_) => None,
+        })
+        .collect()
 }
 
 fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {

--- a/crates/testkit/tests/model.rs
+++ b/crates/testkit/tests/model.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 
 use futures::FutureExt as _;
 use futures::executor::block_on;
-use omnia_guest::model::{Error, Message, Model, Reply, Request, Role, Usage};
-use omnia_testkit::model::Scripted;
+use omnia_guest::model::{Error, McpGrant, Message, Model, Reply, Request, Role, Tool, Usage};
+use omnia_testkit::model::{Harness, Scripted, mcp_grants};
 use omnia_wasi_model::{
     Answer, DirEntry, FutureResult, Reference, ToolHost, VerifyReport, WasiModelCtx,
 };
@@ -94,6 +94,29 @@ fn queue() {
     let reply = complete(&scripted, request("review")).unwrap();
     assert_eq!(serde_json::from_str::<serde_json::Value>(&reply.answer).unwrap(), value);
     scripted.assert_exhausted();
+}
+
+// The recording decorator snapshots every request in call order while
+// delegating to its backend, and surfaces MCP grants for assertion.
+#[test]
+fn harness_records() {
+    let model = Harness::answering(["first"]);
+    let mut granted = request("one");
+    granted.tools.push(Tool::Mcp(McpGrant {
+        name: "probe-references".to_owned(),
+        tools: vec![],
+        url: "http://127.0.0.1:7737/mcp/probe".to_owned(),
+    }));
+
+    assert_eq!(complete(&model, granted).unwrap().answer, "first");
+    model.assert_exhausted();
+
+    let requests = model.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].messages[0].content, "one");
+    let grants = mcp_grants(&requests[0]);
+    assert_eq!(grants.len(), 1);
+    assert_eq!(grants[0].name, "probe-references");
 }
 
 fn complete(model: &impl Model, request: Request) -> Result<Reply, Error> {

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -105,20 +105,20 @@ pub trait Backend: Sized + Sync + Send {
 
 Each interface crate provides guest bindings, a host implementation, and a default backend:
 
-| Crate | Interface | Purpose | Default backend |
-| ----- | --------- | ------- | --------------- |
-| `wasi-http` | `wasi:http` | HTTP client/server (trigger) | `HttpDefault` — hyper client, axum server |
-| `wasi-keyvalue` | `wasi:keyvalue` | Key-value storage | `KeyValueDefault` — in-memory cache |
-| `wasi-messaging` | `wasi:messaging` | Pub/sub messaging (trigger) | `MessagingDefault` — in-process broadcast |
-| `wasi-blobstore` | `wasi:blobstore` | Object/blob storage | `BlobstoreDefault` — in-memory |
-| `wasi-sql` | `wasi:sql` | SQL access + guest ORM | `SqlDefault` — SQLite |
-| `wasi-docstore` | Custom | JSON document store with filters | `DocStoreDefault` — in-memory |
-| `wasi-config` | `wasi:config` | Runtime configuration | `ConfigDefault` — process environment |
-| `wasi-vault` | Custom | Secrets management | `VaultDefault` — in-memory |
-| `wasi-identity` | Custom | Identity/OAuth tokens | `IdentityDefault` — OAuth2 client flow |
-| `wasi-otel` | Custom | Guest OpenTelemetry export | `OtelDefault` — log-only |
-| `wasi-websocket` | Custom | WebSocket connections (trigger) | `WebSocketDefault` — tungstenite server |
-| `wasi-model` | `omnia:model` | Model completions with grants | `ModelDefault` — deterministic echo |
+| Crate            | Interface        | Purpose                          | Default backend                           |
+| ---------------- | ---------------- | -------------------------------- | ----------------------------------------- |
+| `wasi-http`      | `wasi:http`      | HTTP client/server (trigger)     | `HttpDefault` — hyper client, axum server |
+| `wasi-keyvalue`  | `wasi:keyvalue`  | Key-value storage                | `KeyValueDefault` — in-memory cache       |
+| `wasi-messaging` | `wasi:messaging` | Pub/sub messaging (trigger)      | `MessagingDefault` — in-process broadcast |
+| `wasi-blobstore` | `wasi:blobstore` | Object/blob storage              | `BlobstoreDefault` — in-memory            |
+| `wasi-sql`       | `wasi:sql`       | SQL access + guest ORM           | `SqlDefault` — SQLite                     |
+| `wasi-docstore`  | Custom           | JSON document store with filters | `DocStoreDefault` — in-memory             |
+| `wasi-config`    | `wasi:config`    | Runtime configuration            | `ConfigDefault` — process environment     |
+| `wasi-vault`     | Custom           | Secrets management               | `VaultDefault` — in-memory                |
+| `wasi-identity`  | Custom           | Identity/OAuth tokens            | `IdentityDefault` — OAuth2 client flow    |
+| `wasi-otel`      | Custom           | Guest OpenTelemetry export       | `OtelDefault` — log-only                  |
+| `wasi-websocket` | Custom           | WebSocket connections (trigger)  | `WebSocketDefault` — tungstenite server   |
+| `wasi-model`     | `omnia:model`    | Model completions with grants    | `ModelDefault` — deterministic echo       |
 
 Conditional compilation lets one crate serve both sides — guests get bindings on `wasm32`, hosts get the implementation on native:
 

--- a/docs/guides/composing-a-runtime.md
+++ b/docs/guides/composing-a-runtime.md
@@ -62,6 +62,27 @@ cargo run --example cli -- run ./target/wasm32-wasip2/debug/examples/cli_wasm.wa
 
 A backend-less command runtime is valid too: `omnia::runtime!({ mode: command });`.
 
+## Default manifest (`config:`)
+
+The optional `config` key compiles a default manifest path into the generated `main`, used only when the command line supplies no source — no positional wasm, no `--config`, no `OMNIA_CONFIG`:
+
+```rust
+omnia::runtime!({
+    config: concat!(env!("CARGO_MANIFEST_DIR"), "/deploy/omnia.toml"),
+    hosts: {
+        WasiHttp: HttpDefault,
+    }
+});
+```
+
+The value is any expression evaluating to a path. Anchoring it with `env!("CARGO_MANIFEST_DIR")` makes it absolute at compile time, so a bare `run` works from any working directory:
+
+```bash
+cargo run -- run
+```
+
+Explicit sources always win; the compiled-in default is the lowest-precedence fallback.
+
 ## Choosing backends
 
 Every WASI interface ships with a default backend that needs no external service, so a development runtime works out of the box. Swapping to production is a one-line change per interface — the guest `.wasm` is untouched:

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -73,14 +73,14 @@ docker run -v ./guest.wasm:/app.wasm -p 8080:8080 my-runtime
 
 The [`docker/`](../../docker/) directory ships a compose file per service so production backends can be exercised locally:
 
-| File | Service | Matches backend |
-| ---- | ------- | --------------- |
-| `docker/redis.yaml` | Redis | `omnia-redis` |
-| `docker/kafka.yaml` | Apache Kafka | `omnia-kafka` |
-| `docker/nats.yaml` | NATS / JetStream | `omnia-nats` |
-| `docker/postgres.yaml` | PostgreSQL (+ `init.sql`) | `omnia-postgres` |
-| `docker/mongodb.yaml` | MongoDB | `omnia-mongodb` |
-| `docker/otelcol.yaml` | OpenTelemetry Collector | `omnia-opentelemetry` / `OTEL_GRPC_URL` |
+| File                   | Service                   | Matches backend                         |
+| ---------------------- | ------------------------- | --------------------------------------- |
+| `docker/redis.yaml`    | Redis                     | `omnia-redis`                           |
+| `docker/kafka.yaml`    | Apache Kafka              | `omnia-kafka`                           |
+| `docker/nats.yaml`     | NATS / JetStream          | `omnia-nats`                            |
+| `docker/postgres.yaml` | PostgreSQL (+ `init.sql`) | `omnia-postgres`                        |
+| `docker/mongodb.yaml`  | MongoDB                   | `omnia-mongodb`                         |
+| `docker/otelcol.yaml`  | OpenTelemetry Collector   | `omnia-opentelemetry` / `OTEL_GRPC_URL` |
 
 ```bash
 docker compose -f docker/redis.yaml up -d

--- a/docs/guides/multi-guest-deployments.md
+++ b/docs/guides/multi-guest-deployments.md
@@ -12,6 +12,8 @@ Point the runtime at a manifest with `--config` (or the `OMNIA_CONFIG` environme
 cargo run --example http-routing -- run --config examples/http-routing/omnia.toml
 ```
 
+A runtime can also compile in a default manifest path with the `runtime!` macro's `config:` field — used only when the command line supplies no source (see [Composing a Runtime](composing-a-runtime.md#default-manifest-config)).
+
 A manifest declares guests, mounts, routes, and (eventually) transports. Every field is optional except at least one `[[guest]]`. Paths resolve relative to the manifest's own directory.
 
 ```toml

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -10,13 +10,13 @@ Run a single guest, or a manifest-driven deployment.
 <runtime> run [WASM] [--config <omnia.toml>] [--mount <spec>]... [--link <interface>]... [-- <guest args>...]
 ```
 
-| Argument / flag | Meaning |
-| --------------- | ------- |
-| `WASM` | Path to a guest — a standard WASI component (`.wasm`) or a pre-compiled component (`.bin`). Optional when `--config` names a manifest. |
-| `-c, --config <path>` | Deployment manifest (`omnia.toml`) for multi-guest deployments. Falls back to the `OMNIA_CONFIG` environment variable. |
-| `--mount <spec>` | Preopen a host directory into the guest sandbox (repeatable). Layered over the manifest's `[[mount]]` entries; a matching guest-visible name overrides the manifest (last wins). |
-| `--link <interface>` | Host-mediated interface to dispatch on a guest's behalf (repeatable). Unioned with the manifest's per-guest `link` lists. |
-| `-- <args>...` | Everything after `--` is forwarded to the guest as its argv (command mode). `args[0]` is the program name, supplied by the runtime. |
+| Argument / flag       | Meaning                                                                                                                                                                          |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `WASM`                | Path to a guest — a standard WASI component (`.wasm`) or a pre-compiled component (`.bin`). Optional when `--config` names a manifest.                                           |
+| `-c, --config <path>` | Deployment manifest (`omnia.toml`) for multi-guest deployments. Falls back to the `OMNIA_CONFIG` environment variable.                                                           |
+| `--mount <spec>`      | Preopen a host directory into the guest sandbox (repeatable). Layered over the manifest's `[[mount]]` entries; a matching guest-visible name overrides the manifest (last wins). |
+| `--link <interface>`  | Host-mediated interface to dispatch on a guest's behalf (repeatable). Unioned with the manifest's per-guest `link` lists.                                                        |
+| `-- <args>...`        | Everything after `--` is forwarded to the guest as its argv (command mode). `args[0]` is the program name, supplied by the runtime.                                              |
 
 ### Mount spec format
 
@@ -65,8 +65,8 @@ The generated `runtime!` `main` does not dispatch `compile`; call `omnia::compil
 
 ## Cargo features (`omnia` crate)
 
-| Feature | Default | Effect |
-| ------- | ------- | ------ |
-| `jit` | yes | Cranelift JIT; run raw `.wasm` directly and enable `compile`. Disable to run only pre-compiled `.bin` components. |
-| `mpk` | no | Memory protection keys in the pooling allocator (Linux x86-64). |
-| `gc` | no | WebAssembly GC support and pooling GC-heap limits. |
+| Feature | Default | Effect                                                                                                            |
+| ------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| `jit`   | yes     | Cranelift JIT; run raw `.wasm` directly and enable `compile`. Disable to run only pre-compiled `.bin` components. |
+| `mpk`   | no      | Memory protection keys in the pooling allocator (Linux x86-64).                                                   |
+| `gc`    | no      | WebAssembly GC support and pooling GC-heap limits.                                                                |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -12,8 +12,8 @@ Run a single guest, or a manifest-driven deployment.
 
 | Argument / flag       | Meaning                                                                                                                                                                          |
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `WASM`                | Path to a guest — a standard WASI component (`.wasm`) or a pre-compiled component (`.bin`). Optional when `--config` names a manifest.                                           |
-| `-c, --config <path>` | Deployment manifest (`omnia.toml`) for multi-guest deployments. Falls back to the `OMNIA_CONFIG` environment variable.                                                           |
+| `WASM`                | Path to a guest — a standard WASI component (`.wasm`) or a pre-compiled component (`.bin`). Optional when a manifest is available via `--config`, `OMNIA_CONFIG`, or the binary's compiled-in default. |
+| `-c, --config <path>` | Deployment manifest (`omnia.toml`) for multi-guest deployments. Falls back to the `OMNIA_CONFIG` environment variable, then to a default manifest compiled in via the `runtime!` macro's `config:` field (if declared). |
 | `--mount <spec>`      | Preopen a host directory into the guest sandbox (repeatable). Layered over the manifest's `[[mount]]` entries; a matching guest-visible name overrides the manifest (last wins). |
 | `--link <interface>`  | Host-mediated interface to dispatch on a guest's behalf (repeatable). Unioned with the manifest's per-guest `link` lists.                                                        |
 | `-- <args>...`        | Everything after `--` is forwarded to the guest as its argv (command mode). `args[0]` is the program name, supplied by the runtime.                                              |
@@ -37,6 +37,9 @@ path=<host-path>[,name=<guest-name>][,writable]
 
 # Manifest-driven deployment
 <runtime> run --config deploy/omnia.toml
+
+# Compiled-in default manifest (runtime! `config:` field)
+<runtime> run
 
 # Command mode with guest argv
 <runtime> run ./cli_wasm.wasm -- greet Ada

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -55,7 +55,7 @@ Production backend variables (Redis, Kafka, Azure, ...) are listed in [Productio
 
 ## Deployment manifest (`omnia.toml`)
 
-Selected by `--config <path>` or `OMNIA_CONFIG`. The manifest is sparse: every section is optional except at least one `[[guest]]`, and omitted fields fall back to defaults. All relative paths resolve against the manifest's directory.
+Selected by `--config <path>` or `OMNIA_CONFIG`, or compiled in as a default via the `runtime!` macro's `config:` field (see [Composing a Runtime](../guides/composing-a-runtime.md#default-manifest-config)). The manifest is sparse: every section is optional except at least one `[[guest]]`, and omitted fields fall back to defaults. All relative paths resolve against the manifest's directory.
 
 ```toml
 # --- Guests (required, repeatable) -----------------------------------

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -6,35 +6,35 @@ Omnia is configured entirely through environment variables (runtime options and 
 
 ### General
 
-| Variable | Default | Meaning |
-| -------- | ------- | ------- |
-| `RUST_LOG` | unset | Log filter (e.g. `info`, `debug`, `omnia=trace`). Startup logs, including `omnia ready`, are at `info`. |
+| Variable        | Default                                                    | Meaning                                                                                                                                          |
+| --------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `RUST_LOG`      | unset                                                      | Log filter (e.g. `info`, `debug`, `omnia=trace`). Startup logs, including `omnia ready`, are at `info`.                                          |
 | `OTEL_GRPC_URL` | unset (`http://localhost:4317` via OpenTelemetry defaults) | OTLP gRPC endpoint for exporting host traces and metrics. No collector running? Silence export errors with `RUST_LOG=...,opentelemetry_sdk=off`. |
-| `OMNIA_CONFIG` | unset | Path to the deployment manifest; the `--config` flag takes precedence. |
-| `COMPONENT` | derived | Telemetry/component name; defaults to the deployment name (first guest id). |
+| `OMNIA_CONFIG`  | unset                                                      | Path to the deployment manifest; the `--config` flag takes precedence.                                                                           |
+| `COMPONENT`     | derived                                                    | Telemetry/component name; defaults to the deployment name (first guest id).                                                                      |
 
 ### Guest limits
 
-| Variable | Default | Meaning |
-| -------- | ------- | ------- |
-| `GUEST_TIMEOUT_MS` | `30000` | Wall-clock cap on a single guest invocation. |
-| `MAX_MEMORY_BYTES` | `268435456` (256 MiB) | Maximum linear memory a guest may grow to. |
-| `MAX_FUEL` | `0` (off) | Per-invocation fuel budget; `0` disables metering. Compile-affecting. |
-| `MAX_DISPATCH_DEPTH` | `8` | Maximum nesting depth for host-mediated guest-to-guest calls. |
-| `EPOCH_TICK_MS` | `10` | Epoch-increment interval; the yield granularity for CPU-bound guests. |
-| `WASM_BACKTRACE` | `false` | Attach guest backtraces to trap errors. |
+| Variable             | Default               | Meaning                                                               |
+| -------------------- | --------------------- | --------------------------------------------------------------------- |
+| `GUEST_TIMEOUT_MS`   | `30000`               | Wall-clock cap on a single guest invocation.                          |
+| `MAX_MEMORY_BYTES`   | `268435456` (256 MiB) | Maximum linear memory a guest may grow to.                            |
+| `MAX_FUEL`           | `0` (off)             | Per-invocation fuel budget; `0` disables metering. Compile-affecting. |
+| `MAX_DISPATCH_DEPTH` | `8`                   | Maximum nesting depth for host-mediated guest-to-guest calls.         |
+| `EPOCH_TICK_MS`      | `10`                  | Epoch-increment interval; the yield granularity for CPU-bound guests. |
+| `WASM_BACKTRACE`     | `false`               | Attach guest backtraces to trap errors.                               |
 
 ### Instance pooling
 
 The pooling allocator recycles instance slots so per-request instantiation stays cheap.
 
-| Variable | Default | Meaning |
-| -------- | ------- | ------- |
-| `POOLING` | `true` | Enable the pooling instance allocator. |
-| `POOL_MAX_INSTANCES` | `1000` | Maximum component instances held by the pool. |
-| `POOL_MAX_MEMORY_BYTES` | inherits `MAX_MEMORY_BYTES` | Linear-memory size reserved per pooled memory. |
-| `POOL_MAX_UNUSED_WARM_SLOTS` | `100` | Unused warm slots retained for fast reuse. |
-| `POOL_METRICS_INTERVAL_MS` | `5000` | Interval between pool-occupancy metric samples; `0` disables. |
+| Variable                     | Default                     | Meaning                                                       |
+| ---------------------------- | --------------------------- | ------------------------------------------------------------- |
+| `POOLING`                    | `true`                      | Enable the pooling instance allocator.                        |
+| `POOL_MAX_INSTANCES`         | `1000`                      | Maximum component instances held by the pool.                 |
+| `POOL_MAX_MEMORY_BYTES`      | inherits `MAX_MEMORY_BYTES` | Linear-memory size reserved per pooled memory.                |
+| `POOL_MAX_UNUSED_WARM_SLOTS` | `100`                       | Unused warm slots retained for fast reuse.                    |
+| `POOL_METRICS_INTERVAL_MS`   | `5000`                      | Interval between pool-occupancy metric samples; `0` disables. |
 
 Further tunables mirror wasmtime's pooling configuration one-to-one: `POOL_TOTAL_CORE_INSTANCES`, `POOL_TOTAL_MEMORIES`, `POOL_TOTAL_TABLES`, `POOL_TOTAL_STACKS`, `POOL_MEMORY_KEEP_RESIDENT`, `POOL_TABLE_KEEP_RESIDENT`, `POOL_ASYNC_STACK_KEEP_RESIDENT`, `POOL_DECOMMIT_BATCH_SIZE`, `POOL_PAGEMAP_SCAN`, per-component/per-module limits, and (with the `mpk` feature) `POOL_MEMORY_PROTECTION_KEYS`. See `crates/omnia/src/options.rs` for the authoritative list with doc comments.
 
@@ -44,12 +44,12 @@ Further tunables mirror wasmtime's pooling configuration one-to-one: `POOL_TOTAL
 
 ### Default backends
 
-| Variable | Default | Used by |
-| -------- | ------- | ------- |
-| `HTTP_ADDR` | `0.0.0.0:8080` | `HttpDefault` inbound server |
-| `WEBSOCKET_ADDR` | `0.0.0.0:80` | `WebSocketDefault` server |
-| `SQL_DATABASE` | shared in-memory SQLite | `SqlDefault` |
-| `IDENTITY_CLIENT_ID`, `IDENTITY_CLIENT_SECRET`, `IDENTITY_TOKEN_URL` | unset | `IdentityDefault` OAuth flow |
+| Variable                                                             | Default                 | Used by                      |
+| -------------------------------------------------------------------- | ----------------------- | ---------------------------- |
+| `HTTP_ADDR`                                                          | `0.0.0.0:8080`          | `HttpDefault` inbound server |
+| `WEBSOCKET_ADDR`                                                     | `0.0.0.0:80`            | `WebSocketDefault` server    |
+| `SQL_DATABASE`                                                       | shared in-memory SQLite | `SqlDefault`                 |
+| `IDENTITY_CLIENT_ID`, `IDENTITY_CLIENT_SECRET`, `IDENTITY_TOKEN_URL` | unset                   | `IdentityDefault` OAuth flow |
 
 Production backend variables (Redis, Kafka, Azure, ...) are listed in [Production Backends](../guides/production-backends.md#configuration) and each backend crate's README.
 

--- a/examples/Makefile.toml
+++ b/examples/Makefile.toml
@@ -61,9 +61,6 @@ shift
 
 export RUST_LOG="${RUST_LOG:-info,opentelemetry_sdk=off,omnia_wasi_http=debug,${module}=debug}"
 
-# cargo run -p examples --example "$name" -- \
-#   run "${CARGO_TARGET_DIR:-$ws/target}/wasm32-wasip2/debug/examples/${module}_wasm.wasm"
-
 cargo run -p examples --example "$name" -- \
   run "${CARGO_TARGET_DIR:-$ws/target}/wasm32-wasip2/debug/examples/${module}_wasm.wasm" -- "$@"
 '''

--- a/examples/guest-link/README.md
+++ b/examples/guest-link/README.md
@@ -35,8 +35,12 @@ cargo build -p examples \
   --example guest-link-router-wasm \
   --target wasm32-wasip2
 
-# run the host
+# run the host — the manifest path is compiled in (runtime! `config:`),
+# so a bare `run` works from any directory
 export RUST_LOG=info,opentelemetry_sdk=off
+cargo run --example guest-link -- run
+
+# or with an explicit manifest
 cargo run --example guest-link -- run --config examples/guest-link/omnia.toml
 ```
 

--- a/examples/guest-link/omnia.toml
+++ b/examples/guest-link/omnia.toml
@@ -9,9 +9,10 @@
 # The runtime core stays domain-agnostic: `link` and the selector see only the opaque
 # interface string `omnia:link/echo` and opaque guest ids.
 #
-# Build the guests first (see README.md), then run from the repository root:
+# Build the guests first (see README.md), then run (this path is the runtime's
+# compiled-in default, so `--config` is optional):
 #
-#   cargo run --example guest-link -- run --config examples/guest-link/omnia.toml
+#   cargo run --example guest-link -- run
 
 [[guest]]
 id = "responder"

--- a/examples/guest-link/runtime.rs
+++ b/examples/guest-link/runtime.rs
@@ -18,6 +18,7 @@ cfg_if::cfg_if! {
         use omnia_wasi_otel::{WasiOtel, OtelDefault};
 
         omnia::runtime!({
+            config: concat!(env!("CARGO_MANIFEST_DIR"), "/guest-link/omnia.toml"),
             hosts: {
                 WasiHttp: HttpDefault,
                 WasiOtel: OtelDefault,

--- a/examples/http-routing/README.md
+++ b/examples/http-routing/README.md
@@ -13,8 +13,12 @@ This example deploys two guests from a manifest, so build and run stay manual:
 cargo build --example http-routing-a-wasm --target wasm32-wasip2
 cargo build --example http-routing-b-wasm --target wasm32-wasip2
 
-# run the host
+# run the host — the manifest path is compiled in (runtime! `config:`),
+# so a bare `run` works from any directory
 export RUST_LOG="info,opentelemetry_sdk=off,omnia_wasi_http=debug"
+cargo run --example http-routing -- run
+
+# or with an explicit manifest
 cargo run --example http-routing -- run --config examples/http-routing/omnia.toml
 ```
 

--- a/examples/http-routing/omnia.toml
+++ b/examples/http-routing/omnia.toml
@@ -4,9 +4,10 @@
 # and selects the guest per request by longest-prefix match.
 #
 # Source paths are resolved relative to this file's directory. Build the guests
-# first (see README.md), then run from the repository root:
+# first (see README.md), then run (this path is the runtime's compiled-in
+# default, so `--config` is optional):
 #
-#   cargo run --example http-routing -- run --config examples/http-routing/omnia.toml
+#   cargo run --example http-routing -- run
 
 [[guest]]
 id = "a"

--- a/examples/http-routing/runtime.rs
+++ b/examples/http-routing/runtime.rs
@@ -9,6 +9,7 @@ cfg_if::cfg_if! {
         use omnia_wasi_otel::{WasiOtel, OtelDefault};
 
         omnia::runtime!({
+            config: concat!(env!("CARGO_MANIFEST_DIR"), "/http-routing/omnia.toml"),
             hosts: {
                 WasiHttp: HttpDefault,
                 WasiOtel: OtelDefault,

--- a/examples/model/README.md
+++ b/examples/model/README.md
@@ -39,6 +39,9 @@ The answer is scripted in the runtime binary, so no configuration is needed:
 
 ```bash
 export RUST_LOG=info,opentelemetry_sdk=off
+cargo run --example model -- run
+
+# or with an explicit manifest (the default is compiled in via runtime! `config:`)
 cargo run --example model -- run --config examples/model/omnia.toml
 ```
 

--- a/examples/model/omnia.toml
+++ b/examples/model/omnia.toml
@@ -12,9 +12,10 @@
 # scripted double ignores the workspace (it never runs tools); the host-side
 # resolution is proven by the seam suite.
 #
-# Build the guest first (see README.md), then run from the repository root:
+# Build the guest first (see README.md), then run (this path is the runtime's
+# compiled-in default, so `--config` is optional):
 #
-#   cargo run --example model -- run --config examples/model/omnia.toml
+#   cargo run --example model -- run
 
 [[guest]]
 id = "model"

--- a/examples/model/runtime.rs
+++ b/examples/model/runtime.rs
@@ -48,6 +48,7 @@ cfg_if::cfg_if! {
 
         omnia::runtime!({
             mode: command,
+            config: concat!(env!("CARGO_MANIFEST_DIR"), "/model/omnia.toml"),
             hosts: {
                 WasiOtel: OtelDefault,
                 WasiModel: CannedVerdict,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes CLI deployment source resolution and the generated `main`/`omnia::main` ABI; wrong precedence or a bad compiled path could load the wrong manifest, though explicit flags and wasm still override.
> 
> **Overview**
> Adds optional **`config:`** to `omnia::runtime!` so a manifest path (e.g. `concat!(env!("CARGO_MANIFEST_DIR"), "/omnia.toml")`) is baked into generated `main` and passed to **`omnia::main`** as a fallback when the CLI has no wasm, `--config`, or `OMNIA_CONFIG`. **`DeploymentBuilder::default_config`** and updated **`build`** resolution apply that path only if no positional wasm is given (explicit wasm still uses the single-guest shorthand).
> 
> Multi-guest examples (**guest-link**, **http-routing**, **model**) now set **`config:`** so **`cargo run --example … -- run`** works without `--config`; docs and CLI/configuration guides describe precedence.
> 
> For MCP-related testing, **testkit** adds a **`Harness`** `Model` wrapper that records **`Request`**s in order and **`mcp_grants`** to extract **`Tool::Mcp`** entries, with a **`harness_records`** unit test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c47c35bda7a6f5344603ab4bf764263371441fd9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->