### PR TITLE
improve runtime config

### DIFF
--- a/crates/host-macros/README.md
+++ b/crates/host-macros/README.md
@@ -51,6 +51,35 @@ omnia::runtime!({
 - **`mode: command`** — the runtime drives the guest's `wasi:cli/run` export once and exits with its status. A backend-less command runtime is valid: `omnia::runtime!({ mode: command });`
 - **`config:`** — a path expression compiled into the generated `main` as the default manifest, used only when the command line supplies no positional wasm, `--config`, or `OMNIA_CONFIG`. Anchor it with `env!("CARGO_MANIFEST_DIR")` to make it absolute at compile time.
 
+### Inline manifest keys
+
+Instead of a `config:` path, the deployment can be written inline — the keys mirror the `omnia::Manifest` schema (`omnia.toml` as Rust) and expand to a `Manifest` value compiled in as the same lowest-precedence fallback:
+
+```rust,ignore
+omnia::runtime!({
+    guests: [
+        { id: "responder", source: concat!(env!("CARGO_MANIFEST_DIR"), "/responder.wasm") },
+        {
+            id: "router",
+            source: concat!(env!("CARGO_MANIFEST_DIR"), "/router.wasm"),
+            link: ["omnia:link/echo"],   // per-guest host-mediated imports
+        },
+    ],
+    link: ["omnia:shared/log"],          // optional deployment-wide links
+    mounts: [
+        { name: ".", path: concat!(env!("CARGO_MANIFEST_DIR"), "/workspace"), writable: true },
+    ],
+    routes: {
+        http: [{ prefix: "/", guest: "router" }],
+        messaging: [{ topic: "orders.>", guest: "worker" }],
+        websocket: [{ route: "chat.*", guest: "ws" }],
+    },
+    hosts: { /* ... */ }
+});
+```
+
+Every value is a Rust expression; anchor paths with `env!("CARGO_MANIFEST_DIR")` (relative paths resolve against the run-time working directory). `config:` and the inline keys are mutually exclusive.
+
 ## Generated Code
 
 The macro generates a private `runtime` module containing:

--- a/crates/host-macros/src/runtime.rs
+++ b/crates/host-macros/src/runtime.rs
@@ -19,7 +19,7 @@ pub fn expand(config: &Config) -> TokenStream {
         server_types,
         backends_ty,
         backends_def,
-        config_file,
+        default_manifest,
     } = Codegen::from(config);
 
     let mode = match mode {
@@ -62,7 +62,7 @@ pub fn expand(config: &Config) -> TokenStream {
             /// deployment through this runtime's hosts and backends.
             #[tokio::main]
             pub async fn main() -> ::std::process::ExitCode {
-                omnia::main::<#backends_ty, Hooks>(#mode, #config_file).await
+                omnia::main::<#backends_ty, Hooks>(#mode, #default_manifest).await
             }
 
             /// Run one deployment through this runtime's hosts and backends,
@@ -117,6 +117,35 @@ mod tests {
     fn expand_config_file() {
         insta::assert_snapshot!(expand_pretty(quote!({
             config: concat!(env!("CARGO_MANIFEST_DIR"), "/omnia.toml"),
+            hosts: {
+                WasiOtel: OtelDefault,
+            },
+        })));
+    }
+
+    #[test]
+    fn expand_inline_manifest() {
+        insta::assert_snapshot!(expand_pretty(quote!({
+            guests: [
+                {
+                    id: "responder",
+                    source: concat!(env!("CARGO_MANIFEST_DIR"), "/responder.wasm"),
+                },
+                {
+                    id: "router",
+                    source: concat!(env!("CARGO_MANIFEST_DIR"), "/router.wasm"),
+                    link: ["omnia:link/echo"],
+                },
+            ],
+            link: ["omnia:link/other"],
+            mounts: [
+                { name: ".", path: concat!(env!("CARGO_MANIFEST_DIR"), "/workspace"), writable: true },
+            ],
+            routes: {
+                http: [{ prefix: "/", guest: "router" }],
+                messaging: [{ topic: "orders.>", guest: "worker" }],
+                websocket: [{ route: "chat.*", guest: "ws" }],
+            },
             hosts: {
                 WasiOtel: OtelDefault,
             },

--- a/crates/host-macros/src/runtime/codegen.rs
+++ b/crates/host-macros/src/runtime/codegen.rs
@@ -6,7 +6,7 @@ use proc_macro2::TokenStream;
 use quote::{ToTokens, format_ident, quote};
 use syn::{Ident, Path};
 
-use crate::runtime::parse::{Config, HostEntry, Mode};
+use crate::runtime::parse::{Config, HostEntry, ManifestSpec, Mode};
 
 // Token fragments needed to expand the runtime macro.
 pub struct Codegen {
@@ -15,7 +15,7 @@ pub struct Codegen {
     pub server_types: Vec<Path>,
     pub backends_ty: TokenStream,
     pub backends_def: TokenStream,
-    pub config_file: TokenStream,
+    pub default_manifest: TokenStream,
 }
 
 impl From<&Config> for Codegen {
@@ -27,10 +27,7 @@ impl From<&Config> for Codegen {
 
         let (backends_ty, backends_def) = emit_backends(host_entries);
 
-        let config_file = config.config_file.as_ref().map_or_else(
-            || quote! { ::std::option::Option::None },
-            |expr| quote! { ::std::option::Option::Some(::std::path::PathBuf::from(#expr)) },
-        );
+        let default_manifest = emit_default_manifest(config);
 
         Self {
             mode: config.mode,
@@ -38,8 +35,82 @@ impl From<&Config> for Codegen {
             server_types,
             backends_ty,
             backends_def,
-            config_file,
+            default_manifest,
         }
+    }
+}
+
+/// Emit the `Option<omnia::DefaultManifest>` fallback passed to `omnia::main`:
+/// `Path` for a `config:` expression, `Inline` for the inline manifest keys,
+/// `None` when neither is declared.
+fn emit_default_manifest(config: &Config) -> TokenStream {
+    if let Some(expr) = &config.config_file {
+        return quote! {
+            ::std::option::Option::Some(
+                omnia::DefaultManifest::Path(::std::path::PathBuf::from(#expr)),
+            )
+        };
+    }
+    if config.manifest.is_empty() {
+        return quote! { ::std::option::Option::None };
+    }
+
+    let builder = emit_manifest_builder(&config.manifest);
+    quote! {
+        ::std::option::Option::Some(omnia::DefaultManifest::Inline(#builder))
+    }
+}
+
+/// Emit the fluent `omnia::Manifest` builder chain for the inline keys.
+fn emit_manifest_builder(manifest: &ManifestSpec) -> TokenStream {
+    let guests = manifest.guests.iter().map(|guest| {
+        let id = &guest.id;
+        let source = &guest.source;
+        let links = &guest.link;
+        quote! {
+            .guest(omnia::GuestEntry::new(#id, #source)#(.link(#links))*)
+        }
+    });
+
+    let mounts = manifest.mounts.iter().map(|mount| {
+        let name = &mount.name;
+        let path = &mount.path;
+        let writable =
+            mount.writable.as_ref().map_or_else(|| quote!(false), ToTokens::to_token_stream);
+        quote! {
+            .mounts([omnia::Mount {
+                name: ::std::string::String::from(#name),
+                path: ::std::path::PathBuf::from(#path),
+                writable: #writable,
+            }])
+        }
+    });
+
+    let links = &manifest.link;
+    let link = (!links.is_empty()).then(|| quote! { .links([#(#links),*]) });
+
+    let routes = &manifest.routes;
+    let http = routes.http.iter().map(|route| {
+        let (key, guest) = (&route.key, &route.guest);
+        quote! { .route_http(#key, #guest) }
+    });
+    let messaging = routes.messaging.iter().map(|route| {
+        let (key, guest) = (&route.key, &route.guest);
+        quote! { .route_messaging(#key, #guest) }
+    });
+    let websocket = routes.websocket.iter().map(|route| {
+        let (key, guest) = (&route.key, &route.guest);
+        quote! { .route_websocket(#key, #guest) }
+    });
+
+    quote! {
+        omnia::Manifest::new()
+            #(#guests)*
+            #(#mounts)*
+            #link
+            #(#http)*
+            #(#messaging)*
+            #(#websocket)*
     }
 }
 

--- a/crates/host-macros/src/runtime/parse.rs
+++ b/crates/host-macros/src/runtime/parse.rs
@@ -2,6 +2,7 @@
 //!
 //! Parses the runtime macro token stream input into structured values.
 
+use proc_macro2::Span;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::{Expr, Ident, Path, Result, Token};
@@ -20,6 +21,7 @@ pub struct Config {
     pub host_entries: Vec<HostEntry>,
     #[allow(clippy::struct_field_names)]
     pub config_file: Option<Expr>,
+    pub manifest: ManifestSpec,
 }
 
 /// One `Host: Backend` wiring from the `hosts: { ... }` block.
@@ -28,11 +30,67 @@ pub struct HostEntry {
     pub backend: Path,
 }
 
+/// Inline manifest keys (`guests`, `mounts`, `link`, `routes`) parsed from
+/// `runtime!({ ... })`; mirrors the `omnia::Manifest` schema.
+#[derive(Default)]
+pub struct ManifestSpec {
+    pub guests: Vec<GuestSpec>,
+    pub mounts: Vec<MountSpec>,
+    pub link: Vec<Expr>,
+    pub routes: RoutesSpec,
+}
+
+impl ManifestSpec {
+    pub const fn is_empty(&self) -> bool {
+        self.guests.is_empty()
+            && self.mounts.is_empty()
+            && self.link.is_empty()
+            && self.routes.is_empty()
+    }
+}
+
+/// One `{ id: ..., source: ..., link: [...] }` guest entry.
+pub struct GuestSpec {
+    pub id: Expr,
+    pub source: Expr,
+    pub link: Vec<Expr>,
+}
+
+/// One `{ name: ..., path: ..., writable: ... }` mount entry.
+pub struct MountSpec {
+    pub name: Expr,
+    pub path: Expr,
+    pub writable: Option<Expr>,
+}
+
+/// Per-trigger route lists from the `routes: { ... }` block.
+#[derive(Default)]
+pub struct RoutesSpec {
+    pub http: Vec<RouteEntry>,
+    pub messaging: Vec<RouteEntry>,
+    pub websocket: Vec<RouteEntry>,
+}
+
+impl RoutesSpec {
+    const fn is_empty(&self) -> bool {
+        self.http.is_empty() && self.messaging.is_empty() && self.websocket.is_empty()
+    }
+}
+
+/// One route: a match key (`prefix`/`topic`/`route`) mapped to a target guest.
+pub struct RouteEntry {
+    pub key: Expr,
+    pub guest: Expr,
+}
+
 impl Parse for Config {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let mut mode = Mode::default();
         let mut host_entries = Vec::new();
         let mut config_file = None;
+        let mut manifest = ManifestSpec::default();
+        let mut config_span: Option<Span> = None;
+        let mut inline_span: Option<Span> = None;
 
         let settings;
         syn::braced!(settings in input);
@@ -42,14 +100,42 @@ impl Parse for Config {
             match setting.into_value() {
                 Opt::Mode(m) => mode = m,
                 Opt::Hosts(h) => host_entries = h,
-                Opt::Config(c) => config_file = Some(c),
+                Opt::Config(c, span) => {
+                    config_file = Some(c);
+                    config_span = Some(span);
+                }
+                Opt::Guests(g, span) => {
+                    manifest.guests = g;
+                    inline_span.get_or_insert(span);
+                }
+                Opt::Mounts(m, span) => {
+                    manifest.mounts = m;
+                    inline_span.get_or_insert(span);
+                }
+                Opt::Link(l, span) => {
+                    manifest.link = l;
+                    inline_span.get_or_insert(span);
+                }
+                Opt::Routes(r, span) => {
+                    manifest.routes = r;
+                    inline_span.get_or_insert(span);
+                }
             }
+        }
+
+        if let (Some(_), Some(inline)) = (config_span, inline_span) {
+            return Err(syn::Error::new(
+                inline,
+                "`config:` and inline manifest keys (`guests`, `mounts`, `link`, `routes`) are \
+                 mutually exclusive",
+            ));
         }
 
         Ok(Self {
             mode,
             host_entries,
             config_file,
+            manifest,
         })
     }
 }
@@ -58,12 +144,20 @@ mod kw {
     syn::custom_keyword!(mode);
     syn::custom_keyword!(hosts);
     syn::custom_keyword!(config);
+    syn::custom_keyword!(guests);
+    syn::custom_keyword!(mounts);
+    syn::custom_keyword!(link);
+    syn::custom_keyword!(routes);
 }
 
 enum Opt {
     Mode(Mode),
     Hosts(Vec<HostEntry>),
-    Config(Expr),
+    Config(Expr, Span),
+    Guests(Vec<GuestSpec>, Span),
+    Mounts(Vec<MountSpec>, Span),
+    Link(Vec<Expr>, Span),
+    Routes(RoutesSpec, Span),
 }
 
 impl Parse for Opt {
@@ -80,9 +174,25 @@ impl Parse for Opt {
             syn::braced!(list in input);
             Ok(Self::Hosts(parse_host_entries(&list)?))
         } else if l.peek(kw::config) {
-            input.parse::<kw::config>()?;
+            let key = input.parse::<kw::config>()?;
             input.parse::<Token![:]>()?;
-            Ok(Self::Config(input.parse()?))
+            Ok(Self::Config(input.parse()?, key.span))
+        } else if l.peek(kw::guests) {
+            let key = input.parse::<kw::guests>()?;
+            input.parse::<Token![:]>()?;
+            Ok(Self::Guests(parse_bracketed_list(input)?, key.span))
+        } else if l.peek(kw::mounts) {
+            let key = input.parse::<kw::mounts>()?;
+            input.parse::<Token![:]>()?;
+            Ok(Self::Mounts(parse_bracketed_list(input)?, key.span))
+        } else if l.peek(kw::link) {
+            let key = input.parse::<kw::link>()?;
+            input.parse::<Token![:]>()?;
+            Ok(Self::Link(parse_expr_list(input)?, key.span))
+        } else if l.peek(kw::routes) {
+            let key = input.parse::<kw::routes>()?;
+            input.parse::<Token![:]>()?;
+            Ok(Self::Routes(input.parse()?, key.span))
         } else {
             Err(l.error())
         }
@@ -112,4 +222,170 @@ impl Parse for HostEntry {
 
 fn parse_host_entries(input: ParseStream) -> Result<Vec<HostEntry>> {
     Ok(Punctuated::<HostEntry, Token![,]>::parse_terminated(input)?.into_iter().collect())
+}
+
+/// Parse `[ item, item, ... ]` where each item implements [`Parse`].
+fn parse_bracketed_list<T: Parse>(input: ParseStream) -> Result<Vec<T>> {
+    let list;
+    syn::bracketed!(list in input);
+    Ok(Punctuated::<T, Token![,]>::parse_terminated(&list)?.into_iter().collect())
+}
+
+/// Parse `[ expr, expr, ... ]`.
+fn parse_expr_list(input: ParseStream) -> Result<Vec<Expr>> {
+    parse_bracketed_list::<Expr>(input)
+}
+
+impl Parse for GuestSpec {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let content;
+        let brace = syn::braced!(content in input);
+        let mut id = None;
+        let mut source = None;
+        let mut link = Vec::new();
+
+        while !content.is_empty() {
+            let key: Ident = content.parse()?;
+            content.parse::<Token![:]>()?;
+            match key.to_string().as_str() {
+                "id" => id = Some(content.parse()?),
+                "source" => source = Some(content.parse()?),
+                "link" => link = parse_expr_list(&content)?,
+                other => {
+                    return Err(syn::Error::new(
+                        key.span(),
+                        format!("unknown guest key `{other}`; expected `id`, `source`, or `link`"),
+                    ));
+                }
+            }
+            if !content.is_empty() {
+                content.parse::<Token![,]>()?;
+            }
+        }
+
+        let missing =
+            |key| syn::Error::new(brace.span.join(), format!("guest entry is missing `{key}`"));
+        Ok(Self {
+            id: id.ok_or_else(|| missing("id"))?,
+            source: source.ok_or_else(|| missing("source"))?,
+            link,
+        })
+    }
+}
+
+impl Parse for MountSpec {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let content;
+        let brace = syn::braced!(content in input);
+        let mut name = None;
+        let mut path = None;
+        let mut writable = None;
+
+        while !content.is_empty() {
+            let key: Ident = content.parse()?;
+            content.parse::<Token![:]>()?;
+            match key.to_string().as_str() {
+                "name" => name = Some(content.parse()?),
+                "path" => path = Some(content.parse()?),
+                "writable" => writable = Some(content.parse()?),
+                other => {
+                    return Err(syn::Error::new(
+                        key.span(),
+                        format!(
+                            "unknown mount key `{other}`; expected `name`, `path`, or `writable`"
+                        ),
+                    ));
+                }
+            }
+            if !content.is_empty() {
+                content.parse::<Token![,]>()?;
+            }
+        }
+
+        let missing =
+            |key| syn::Error::new(brace.span.join(), format!("mount entry is missing `{key}`"));
+        Ok(Self {
+            name: name.ok_or_else(|| missing("name"))?,
+            path: path.ok_or_else(|| missing("path"))?,
+            writable,
+        })
+    }
+}
+
+impl Parse for RoutesSpec {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let content;
+        syn::braced!(content in input);
+        let mut routes = Self::default();
+
+        while !content.is_empty() {
+            let key: Ident = content.parse()?;
+            content.parse::<Token![:]>()?;
+            match key.to_string().as_str() {
+                "http" => routes.http = parse_route_entries(&content, "prefix")?,
+                "messaging" => routes.messaging = parse_route_entries(&content, "topic")?,
+                "websocket" => routes.websocket = parse_route_entries(&content, "route")?,
+                other => {
+                    return Err(syn::Error::new(
+                        key.span(),
+                        format!(
+                            "unknown route trigger `{other}`; expected `http`, `messaging`, or \
+                             `websocket`"
+                        ),
+                    ));
+                }
+            }
+            if !content.is_empty() {
+                content.parse::<Token![,]>()?;
+            }
+        }
+
+        Ok(routes)
+    }
+}
+
+/// Parse `[ { <match_key>: ..., guest: ... }, ... ]` route entries; the match
+/// key is `prefix` (http), `topic` (messaging), or `route` (websocket).
+fn parse_route_entries(input: ParseStream, match_key: &str) -> Result<Vec<RouteEntry>> {
+    let list;
+    syn::bracketed!(list in input);
+    let mut entries = Vec::new();
+
+    while !list.is_empty() {
+        let content;
+        let brace = syn::braced!(content in list);
+        let mut key = None;
+        let mut guest = None;
+
+        while !content.is_empty() {
+            let field: Ident = content.parse()?;
+            content.parse::<Token![:]>()?;
+            match field.to_string().as_str() {
+                k if k == match_key => key = Some(content.parse()?),
+                "guest" => guest = Some(content.parse()?),
+                other => {
+                    return Err(syn::Error::new(
+                        field.span(),
+                        format!("unknown route key `{other}`; expected `{match_key}` or `guest`"),
+                    ));
+                }
+            }
+            if !content.is_empty() {
+                content.parse::<Token![,]>()?;
+            }
+        }
+
+        let missing =
+            |key| syn::Error::new(brace.span.join(), format!("route entry is missing `{key}`"));
+        entries.push(RouteEntry {
+            key: key.ok_or_else(|| missing(match_key))?,
+            guest: guest.ok_or_else(|| missing("guest"))?,
+        });
+
+        if !list.is_empty() {
+            list.parse::<Token![,]>()?;
+        }
+    }
+
+    Ok(entries)
 }

--- a/crates/host-macros/src/snapshots/omnia_host_macros__runtime__tests__expand_config_file.snap
+++ b/crates/host-macros/src/snapshots/omnia_host_macros__runtime__tests__expand_config_file.snap
@@ -50,8 +50,10 @@ mod runtime {
         >(
                 omnia::Mode::Server,
                 ::std::option::Option::Some(
-                    ::std::path::PathBuf::from(
-                        concat!(env!("CARGO_MANIFEST_DIR"), "/omnia.toml"),
+                    omnia::DefaultManifest::Path(
+                        ::std::path::PathBuf::from(
+                            concat!(env!("CARGO_MANIFEST_DIR"), "/omnia.toml"),
+                        ),
                     ),
                 ),
             )

--- a/crates/host-macros/src/snapshots/omnia_host_macros__runtime__tests__expand_inline_manifest.snap
+++ b/crates/host-macros/src/snapshots/omnia_host_macros__runtime__tests__expand_inline_manifest.snap
@@ -1,0 +1,94 @@
+---
+source: crates/host-macros/src/runtime.rs
+expression: "expand_pretty(quote!({\n    guests:\n    [{\n        id: \"responder\", source:\n        concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/responder.wasm\"),\n    },\n    {\n        id: \"router\", source:\n        concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/router.wasm\"), link:\n        [\"omnia:link/echo\"],\n    },], link: [\"omnia:link/other\"], mounts:\n    [{\n        name: \".\", path: concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/workspace\"),\n        writable: true\n    },], routes:\n    {\n        http: [{ prefix: \"/\", guest: \"router\" }], messaging:\n        [{ topic: \"orders.>\", guest: \"worker\" }], websocket:\n        [{ route: \"chat.*\", guest: \"ws\" }],\n    }, hosts: { WasiOtel: OtelDefault, },\n}))"
+---
+mod runtime {
+    use anyhow::Result;
+    use omnia::futures::future;
+    use omnia::Server;
+    use omnia::tokio;
+    use super::*;
+    use omnia::Backend;
+    #[derive(Clone)]
+    struct Backends {
+        otel_default: OtelDefault,
+    }
+    impl omnia::Backends for Backends {
+        async fn connect() -> Result<Self> {
+            let (otel_default,) = tokio::try_join!(
+                < OtelDefault as Backend > ::connect(),
+            )?;
+            Ok(Self { otel_default })
+        }
+    }
+    impl omnia_wasi_otel::HasOtel for Backends {
+        fn otel_ctx(&mut self) -> &mut dyn omnia_wasi_otel::WasiOtelCtx {
+            &mut self.otel_default
+        }
+    }
+    struct Hooks;
+    impl omnia::Wiring<Backends> for Hooks {
+        fn link(
+            deployment: &mut omnia::Deployment<omnia::StoreCtx<Backends>>,
+        ) -> Result<()> {
+            deployment.host::<WasiOtel, Backends>()?;
+            Ok(())
+        }
+        async fn serve(runtime: &omnia::Runtime<Backends>) -> Result<()> {
+            let servers: Vec<future::BoxFuture<'_, Result<()>>> = vec![];
+            future::try_join_all(servers).await?;
+            Ok(())
+        }
+    }
+    /// CLI entry point: parse the `run` grammar, then run the
+    /// deployment through this runtime's hosts and backends.
+    #[tokio::main]
+    pub async fn main() -> ::std::process::ExitCode {
+        omnia::main::<
+            Backends,
+            Hooks,
+        >(
+                omnia::Mode::Server,
+                ::std::option::Option::Some(
+                    omnia::DefaultManifest::Inline(
+                        omnia::Manifest::new()
+                            .guest(
+                                omnia::GuestEntry::new(
+                                    "responder",
+                                    concat!(env!("CARGO_MANIFEST_DIR"), "/responder.wasm"),
+                                ),
+                            )
+                            .guest(
+                                omnia::GuestEntry::new(
+                                        "router",
+                                        concat!(env!("CARGO_MANIFEST_DIR"), "/router.wasm"),
+                                    )
+                                    .link("omnia:link/echo"),
+                            )
+                            .mounts([
+                                omnia::Mount {
+                                    name: ::std::string::String::from("."),
+                                    path: ::std::path::PathBuf::from(
+                                        concat!(env!("CARGO_MANIFEST_DIR"), "/workspace"),
+                                    ),
+                                    writable: true,
+                                },
+                            ])
+                            .links(["omnia:link/other"])
+                            .route_http("/", "router")
+                            .route_messaging("orders.>", "worker")
+                            .route_websocket("chat.*", "ws"),
+                    ),
+                ),
+            )
+            .await
+    }
+    /// Run one deployment through this runtime's hosts and backends,
+    /// blocking until the guest completes.
+    #[tokio::main]
+    pub async fn run(builder: omnia::DeploymentBuilder) -> Result<omnia::ExitStatus> {
+        omnia::run::<Backends, Hooks>(builder.mode(omnia::Mode::Server)).await
+    }
+}
+#[allow(unused_imports)]
+pub use runtime::{run, main};

--- a/crates/host-macros/tests/compile_fail/config_and_inline.rs
+++ b/crates/host-macros/tests/compile_fail/config_and_inline.rs
@@ -1,0 +1,8 @@
+omnia_host_macros::runtime!({
+    config: "omnia.toml",
+    guests: [
+        { id: "api", source: "api.wasm" },
+    ],
+});
+
+fn main() {}

--- a/crates/host-macros/tests/compile_fail/config_and_inline.stderr
+++ b/crates/host-macros/tests/compile_fail/config_and_inline.stderr
@@ -1,0 +1,5 @@
+error: `config:` and inline manifest keys (`guests`, `mounts`, `link`, `routes`) are mutually exclusive
+ --> tests/compile_fail/config_and_inline.rs:3:5
+  |
+3 |     guests: [
+  |     ^^^^^^

--- a/crates/host-macros/tests/compile_fail/unknown_key.rs
+++ b/crates/host-macros/tests/compile_fail/unknown_key.rs
@@ -1,5 +1,5 @@
 omnia_host_macros::runtime!({
-    guests: {},
+    backends: {},
 });
 
 fn main() {}

--- a/crates/host-macros/tests/compile_fail/unknown_key.stderr
+++ b/crates/host-macros/tests/compile_fail/unknown_key.stderr
@@ -1,5 +1,5 @@
-error: expected one of: `mode`, `hosts`, `config`
+error: expected one of: `mode`, `hosts`, `config`, `guests`, `mounts`, `link`, `routes`
  --> tests/compile_fail/unknown_key.rs:2:5
   |
-2 |     guests: {},
-  |     ^^^^^^
+2 |     backends: {},
+  |     ^^^^^^^^

--- a/crates/omnia/src/lib.rs
+++ b/crates/omnia/src/lib.rs
@@ -40,7 +40,7 @@ pub use self::registry::{
 };
 pub use self::runtime::{Backends, ExitStatus, Mode, Runtime, Wiring};
 #[doc(hidden)]
-pub use self::runtime::{main, run, run_precompiled};
+pub use self::runtime::{DefaultManifest, main, run, run_precompiled};
 pub use self::store::{
     HasDispatcher, HasHttp, HasLimits, HasMounts, StoreBase, StoreBaseBuilder, StoreCtx,
 };

--- a/crates/omnia/src/runtime.rs
+++ b/crates/omnia/src/runtime.rs
@@ -80,13 +80,37 @@ pub trait Wiring<B: Backends> {
     fn serve(runtime: &Runtime<B>) -> impl std::future::Future<Output = Result<()>> + Send;
 }
 
+/// A runtime's compiled-in deployment fallback, used only when the CLI
+/// supplies no source.
+///
+/// The `runtime!` macro emits [`Path`](Self::Path) for its `config:` field and
+/// [`Inline`](Self::Inline) for its inline manifest keys (`guests`, `mounts`,
+/// `link`, `routes`).
+#[derive(Clone, Debug)]
+pub enum DefaultManifest {
+    /// A default manifest path, loaded only when the fallback is reached.
+    Path(std::path::PathBuf),
+    /// A manifest value assembled at compile time.
+    Inline(Manifest),
+}
+
+impl DefaultManifest {
+    /// Resolve the fallback into a manifest, loading the file for the path kind.
+    fn into_manifest(self) -> Result<Manifest> {
+        match self {
+            Self::Path(path) => Manifest::from_config(path),
+            Self::Inline(manifest) => Ok(manifest),
+        }
+    }
+}
+
 /// CLI entry point for generated `main` functions.
 ///
-/// `default_config` is the runtime's compiled-in manifest fallback (the
-/// `runtime!` macro's `config:` field), used only when the CLI supplies no
-/// source.
+/// `default_manifest` is the runtime's compiled-in deployment fallback (the
+/// `runtime!` macro's `config:` field or inline manifest keys), used only when
+/// the CLI supplies no source.
 #[doc(hidden)]
-pub async fn main<B, H>(mode: Mode, default_config: Option<std::path::PathBuf>) -> ExitCode
+pub async fn main<B, H>(mode: Mode, default_manifest: Option<DefaultManifest>) -> ExitCode
 where
     B: Backends,
     H: Wiring<B>,
@@ -105,12 +129,12 @@ where
                     || {
                         wasm.map_or_else(
                             || {
-                                default_config
+                                default_manifest
                                     .context(
                                         "no guest specified: pass a <wasm> path, or --config \
                                          <omnia.toml> (or set OMNIA_CONFIG)",
                                     )
-                                    .and_then(Manifest::from_config)
+                                    .and_then(DefaultManifest::into_manifest)
                             },
                             |wasm| Ok(Manifest::from_wasm(wasm)),
                         )

--- a/docs/guides/composing-a-runtime.md
+++ b/docs/guides/composing-a-runtime.md
@@ -83,6 +83,44 @@ cargo run -- run
 
 Explicit sources always win; the compiled-in default is the lowest-precedence fallback.
 
+## Inline manifest (`guests:`, `mounts:`, `link:`, `routes:`)
+
+Everything `omnia.toml` expresses can also be written directly in the macro, mirroring the `omnia::Manifest` schema. The macro expands the keys to a `Manifest` value compiled into the generated `main` as the same lowest-precedence fallback as `config:` — used only when the command line supplies no source:
+
+```rust
+omnia::runtime!({
+    guests: [
+        {
+            id: "responder",
+            source: concat!(env!("CARGO_MANIFEST_DIR"), "/guests/responder.wasm"),
+        },
+        {
+            id: "router",
+            source: concat!(env!("CARGO_MANIFEST_DIR"), "/guests/router.wasm"),
+            link: ["omnia:link/echo"],       // per-guest host-mediated imports
+        },
+    ],
+    link: ["omnia:shared/log"],              // optional deployment-wide links
+    mounts: [
+        { name: ".", path: concat!(env!("CARGO_MANIFEST_DIR"), "/workspace"), writable: true },
+    ],
+    routes: {
+        http: [{ prefix: "/", guest: "router" }],
+        messaging: [{ topic: "orders.>", guest: "worker" }],
+        websocket: [{ route: "chat.*", guest: "ws" }],
+    },
+    hosts: {
+        WasiHttp: HttpDefault,
+    }
+});
+```
+
+- Each value is any Rust expression evaluating to the field's type (strings for ids, interfaces, and route keys; paths for `source` and mount `path`; a bool for `writable`, which defaults to `false`).
+- Relative paths resolve against the process working directory at run time, so anchor them with `env!("CARGO_MANIFEST_DIR")` as with `config:`.
+- `config:` and the inline keys are mutually exclusive — a runtime compiles in a manifest path or a manifest value, not both.
+
+The [`guest-link`](../../examples/guest-link/runtime.rs) example is built this way; its [`omnia.toml`](../../examples/guest-link/Omnia.toml) expresses the same deployment as a file for `--config`.
+
 ## Choosing backends
 
 Every WASI interface ships with a default backend that needs no external service, so a development runtime works out of the box. Swapping to production is a one-line change per interface — the guest `.wasm` is untouched:

--- a/docs/guides/multi-guest-deployments.md
+++ b/docs/guides/multi-guest-deployments.md
@@ -12,7 +12,7 @@ Point the runtime at a manifest with `--config` (or the `OMNIA_CONFIG` environme
 cargo run --example http-routing -- run --config examples/http-routing/omnia.toml
 ```
 
-A runtime can also compile in a default manifest path with the `runtime!` macro's `config:` field — used only when the command line supplies no source (see [Composing a Runtime](composing-a-runtime.md#default-manifest-config)).
+A runtime can also compile in a default deployment with the `runtime!` macro — a manifest path via the `config:` field, or the manifest itself via the inline `guests`/`mounts`/`link`/`routes` keys — used only when the command line supplies no source (see [Composing a Runtime](composing-a-runtime.md#default-manifest-config)).
 
 A manifest declares guests, mounts, routes, and (eventually) transports. Every field is optional except at least one `[[guest]]`. Paths resolve relative to the manifest's own directory.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -13,7 +13,7 @@ Run a single guest, or a manifest-driven deployment.
 | Argument / flag       | Meaning                                                                                                                                                                          |
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `WASM`                | Path to a guest — a standard WASI component (`.wasm`) or a pre-compiled component (`.bin`). Optional when a manifest is available via `--config`, `OMNIA_CONFIG`, or the binary's compiled-in default. |
-| `-c, --config <path>` | Deployment manifest (`omnia.toml`) for multi-guest deployments. Falls back to the `OMNIA_CONFIG` environment variable, then to a default manifest compiled in via the `runtime!` macro's `config:` field (if declared). |
+| `-c, --config <path>` | Deployment manifest (`omnia.toml`) for multi-guest deployments. Falls back to the `OMNIA_CONFIG` environment variable, then to a default manifest compiled in via the `runtime!` macro's `config:` field or inline manifest keys (if declared). |
 | `--mount <spec>`      | Preopen a host directory into the guest sandbox (repeatable). Layered over the manifest's `[[mount]]` entries; a matching guest-visible name overrides the manifest (last wins). |
 | `--link <interface>`  | Host-mediated interface to dispatch on a guest's behalf (repeatable). Unioned with the manifest's top-level `link` list and per-guest `link` lists.                              |
 | `-- <args>...`        | Everything after `--` is forwarded to the guest as its argv (command mode). `args[0]` is the program name, supplied by the runtime.                                              |
@@ -38,7 +38,7 @@ path=<host-path>[,name=<guest-name>][,writable]
 # Manifest-driven deployment
 <runtime> run --config deploy/omnia.toml
 
-# Compiled-in default manifest (runtime! `config:` field)
+# Compiled-in default manifest (runtime! `config:` field or inline manifest keys)
 <runtime> run
 
 # Command mode with guest argv

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -55,7 +55,7 @@ Production backend variables (Redis, Kafka, Azure, ...) are listed in [Productio
 
 ## Deployment manifest (`omnia.toml`)
 
-Selected by `--config <path>` or `OMNIA_CONFIG`, or compiled in as a default via the `runtime!` macro's `config:` field (see [Composing a Runtime](../guides/composing-a-runtime.md#default-manifest-config)). The manifest is sparse: every section is optional except at least one `[[guest]]`, and omitted fields fall back to defaults. All relative paths resolve against the manifest's directory.
+Selected by `--config <path>` or `OMNIA_CONFIG`, or compiled in as a default via the `runtime!` macro's `config:` field or inline manifest keys (see [Composing a Runtime](../guides/composing-a-runtime.md#default-manifest-config)). The manifest is sparse: every section is optional except at least one `[[guest]]`, and omitted fields fall back to defaults. All relative paths resolve against the manifest's directory.
 
 The same schema is constructible programmatically as an `omnia::Manifest` value (`Manifest::new()` with the fluent `guest`/`mounts`/`links`/`route_*` setters, or `Manifest::from_wasm` for the one-guest shorthand) and passed to `DeploymentBuilder::new().manifest(...)` — see [Multi-Guest Deployments](../guides/multi-guest-deployments.md#programmatic-manifests). Either way, the invariants (at least one guest, unique ids, in-process transport) are validated when the deployment is built.
 

--- a/examples/guest-link/README.md
+++ b/examples/guest-link/README.md
@@ -6,7 +6,7 @@ Proves host-mediated dynamic linking: one guest reaches another through an inter
 
 - `responder` ([`responder.rs`](responder.rs)) **exports** `omnia:link/echo`. It declares no trigger of its own, so it is reachable *only* via dispatch.
 - `router` ([`router.rs`](router.rs)) **imports** `omnia:link/echo` and exposes `run(message)`. Its component does not satisfy the import.
-- [`omnia.toml`](omnia.toml), or the equivalent programmatic [`Manifest`](dynamic.rs), names `omnia:link/echo` in the router's `link` allow-list. The runtime core polyfills that import onto the shared linker and, at startup, wires the serve side of every linked interface.
+- The [`runtime!` inline manifest](runtime.rs) — equivalently [`omnia.toml`](omnia.toml) for `--config`, or the programmatic [`Manifest`](dynamic.rs) — names `omnia:link/echo` in the router's `link` allow-list. The runtime core polyfills that import onto the shared linker and, at startup, wires the serve side of every linked interface.
 
 When `router.run("hello")` calls the imported `echo("responder", "hello")`:
 
@@ -36,8 +36,8 @@ cargo build -p examples \
   --example guest-link-extra-wasm \
   --target wasm32-wasip2
 
-# run the host — the manifest path is compiled in (runtime! `config:`),
-# so a bare `run` works from any directory
+# run the host — the deployment is compiled in (runtime! inline manifest
+# keys), so a bare `run` works from any directory
 export RUST_LOG=info,opentelemetry_sdk=off
 cargo run --example guest-link -- run
 

--- a/examples/guest-link/runtime.rs
+++ b/examples/guest-link/runtime.rs
@@ -1,6 +1,7 @@
 //! Host-mediated dynamic linking example runtime.
 //!
-//! Two guests are registered from `omnia.toml`: `responder` (exports
+//! Two guests are compiled in via the `runtime!` macro's inline manifest keys
+//! (the Rust equivalent of `omnia.toml`): `responder` (exports
 //! `omnia:link/echo`) and `router` (imports it, exports `run`). The router's
 //! import is unsatisfied by its own component — the host polyfills it on the
 //! shared linker and, at bootstrap, wires the serve side of every linked
@@ -18,7 +19,23 @@ cfg_if::cfg_if! {
         use omnia_wasi_otel::{WasiOtel, OtelDefault};
 
         omnia::runtime!({
-            config: concat!(env!("CARGO_MANIFEST_DIR"), "/guest-link/omnia.toml"),
+            guests: [
+                {
+                    id: "responder",
+                    source: concat!(
+                        env!("CARGO_MANIFEST_DIR"),
+                        "/../target/wasm32-wasip2/debug/examples/guest_link_responder_wasm.wasm",
+                    ),
+                },
+                {
+                    id: "router",
+                    source: concat!(
+                        env!("CARGO_MANIFEST_DIR"),
+                        "/../target/wasm32-wasip2/debug/examples/guest_link_router_wasm.wasm",
+                    ),
+                    link: ["omnia:link/echo"],
+                },
+            ],
             hosts: {
                 WasiHttp: HttpDefault,
                 WasiOtel: OtelDefault,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes default deployment resolution for generated binaries and macro expansion; behavior is well-tested but affects every `runtime!` user’s compiled-in fallback path.
> 
> **Overview**
> Adds **inline deployment manifests** to `omnia::runtime!` so guests, mounts, links, and routes can be compiled in as Rust (mirroring `omnia.toml`) instead of only a `config:` file path.
> 
> The macro parser accepts `guests`, `mounts`, `link`, and `routes` and rejects mixing them with `config:`. Codegen expands inline keys to a fluent `Manifest::new()...` chain. Generated `main` now passes `Option<DefaultManifest>` (`Path` or `Inline`) into `omnia::main`, which resolves the fallback when the CLI has no wasm, `--config`, or `OMNIA_CONFIG`.
> 
> Docs and the **guest-link** example switch from `config: .../omnia.toml` to an inline manifest; snapshots and compile-fail tests cover expansion and mutual exclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbc0096c8365ebb809696abec2bfe5112bcde500. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->