### PR TITLE
Release 0.35.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -900,9 +900,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "email_address"
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "examples"
-version = "0.36.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "omnia"
-version = "0.36.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2148,7 +2148,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-guest"
-version = "0.36.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-guest-macros"
-version = "0.36.0"
+version = "0.35.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-host-macros"
-version = "0.36.0"
+version = "0.35.0"
 dependencies = [
  "insta",
  "prettyplease 0.3.0",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-seam-suite"
-version = "0.36.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2239,7 +2239,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-testkit"
-version = "0.36.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2259,7 +2259,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-wasi-blobstore"
-version = "0.36.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2274,7 +2274,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-wasi-config"
-version = "0.36.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "omnia",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-wasi-docstore"
-version = "0.36.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2301,7 +2301,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-wasi-http"
-version = "0.36.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-wasi-identity"
-version = "0.36.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "fromenv",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-wasi-keyvalue"
-version = "0.36.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-wasi-messaging"
-version = "0.36.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-wasi-model"
-version = "0.36.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "cap-primitives",
@@ -2403,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-wasi-otel"
-version = "0.36.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2426,7 +2426,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-wasi-sql"
-version = "0.36.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "base64ct",
@@ -2447,7 +2447,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-wasi-vault"
-version = "0.36.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "omnia-wasi-websocket"
-version = "0.36.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -3258,9 +3258,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -5241,7 +5241,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 [[package]]
 name = "wrpc-introspect"
 version = "0.7.0"
-source = "git+https://github.com/bytecodealliance/wrpc#52e5d7f13d5a1d9073bde734e01b27cd77202473"
+source = "git+https://github.com/bytecodealliance/wrpc#f4e36b24517ffcb513a580b4a6a39d631003891e"
 dependencies = [
  "wit-parser 0.251.0",
 ]
@@ -5249,7 +5249,7 @@ dependencies = [
 [[package]]
 name = "wrpc-transport"
 version = "0.29.0"
-source = "git+https://github.com/bytecodealliance/wrpc#52e5d7f13d5a1d9073bde734e01b27cd77202473"
+source = "git+https://github.com/bytecodealliance/wrpc#f4e36b24517ffcb513a580b4a6a39d631003891e"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5266,7 +5266,7 @@ dependencies = [
 [[package]]
 name = "wrpc-wasmtime"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wrpc#52e5d7f13d5a1d9073bde734e01b27cd77202473"
+source = "git+https://github.com/bytecodealliance/wrpc#f4e36b24517ffcb513a580b4a6a39d631003891e"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["runtime", "wasi", "wasm", "wasmtime", "component-model"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/augentic/omnia"
 rust-version = "1.95"
-version = "0.36.0"
+version = "0.35.0"
 
 [workspace.lints.rust]
 # https://dirname.github.io/rust-std-doc/rustc/lints/listing/allowed-by-default.html
@@ -128,23 +128,23 @@ wrpc-transport = "0.29.0"
 wrpc-wasmtime = "0.1.0"
 
 # internally referenced crates
-omnia = { path = "crates/omnia", version = "0.36.0" }
-omnia-guest = { path = "crates/omnia-guest", version = "0.36.0" }
-omnia-guest-macros = { path = "crates/guest-macros", version = "0.36.0" }
-omnia-host-macros = { path = "crates/host-macros", version = "0.36.0" }
+omnia = { path = "crates/omnia", version = "0.35.0" }
+omnia-guest = { path = "crates/omnia-guest", version = "0.35.0" }
+omnia-guest-macros = { path = "crates/guest-macros", version = "0.35.0" }
+omnia-host-macros = { path = "crates/host-macros", version = "0.35.0" }
 omnia-testkit = { path = "crates/testkit" }
-omnia-wasi-blobstore = { path = "crates/wasi-blobstore", version = "0.36.0" }
-omnia-wasi-config = { path = "crates/wasi-config", version = "0.36.0" }
-omnia-wasi-docstore = { path = "crates/wasi-docstore", version = "0.36.0" }
-omnia-wasi-http = { path = "crates/wasi-http", version = "0.36.0" }
-omnia-wasi-identity = { path = "crates/wasi-identity", version = "0.36.0" }
-omnia-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "0.36.0" }
-omnia-wasi-messaging = { path = "crates/wasi-messaging", version = "0.36.0" }
-omnia-wasi-model = { path = "crates/wasi-model", version = "0.36.0" }
-omnia-wasi-otel = { path = "crates/wasi-otel", version = "0.36.0" }
-omnia-wasi-sql = { path = "crates/wasi-sql", version = "0.36.0" }
-omnia-wasi-vault = { path = "crates/wasi-vault", version = "0.36.0" }
-omnia-wasi-websocket = { path = "crates/wasi-websocket", version = "0.36.0" }
+omnia-wasi-blobstore = { path = "crates/wasi-blobstore", version = "0.35.0" }
+omnia-wasi-config = { path = "crates/wasi-config", version = "0.35.0" }
+omnia-wasi-docstore = { path = "crates/wasi-docstore", version = "0.35.0" }
+omnia-wasi-http = { path = "crates/wasi-http", version = "0.35.0" }
+omnia-wasi-identity = { path = "crates/wasi-identity", version = "0.35.0" }
+omnia-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "0.35.0" }
+omnia-wasi-messaging = { path = "crates/wasi-messaging", version = "0.35.0" }
+omnia-wasi-model = { path = "crates/wasi-model", version = "0.35.0" }
+omnia-wasi-otel = { path = "crates/wasi-otel", version = "0.35.0" }
+omnia-wasi-sql = { path = "crates/wasi-sql", version = "0.35.0" }
+omnia-wasi-vault = { path = "crates/wasi-vault", version = "0.35.0" }
+omnia-wasi-websocket = { path = "crates/wasi-websocket", version = "0.35.0" }
 
 [patch.crates-io]
 wrpc-transport = { git = "https://github.com/bytecodealliance/wrpc" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,4 +1,4 @@
-## 0.36.0
+## 0.35.0
 
 Released 2026-07-25
 
@@ -69,7 +69,6 @@ Released 2026-07-25
 Release notes for previous releases can be found on the respective release branches of the repository.
 
 <!-- ARCHIVE_START -->
-* [0.36.x](https://github.com/augentic/omnia/blob/release-0.36.0/RELEASES.md)
 * [0.35.x](https://github.com/augentic/omnia/blob/release-0.35.0/RELEASES.md)
 * [0.34.x](https://github.com/augentic/omnia/blob/release-0.34.0/RELEASES.md)
 * [0.33.x](https://github.com/augentic/omnia/blob/release-0.33.0/RELEASES.md)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,13 +4,43 @@ Unreleased
 
 ### Added
 
+- Multi-guest registry: one process hosts many Wasm components on a shared
+  engine/linker, selected by opaque `GuestId`, with instance-per-call
+  instantiation, route tables, and host-mediated guest-to-guest linking
+- Resolve-on-miss `GuestResolver` so missing guests can be faulted in at
+  dispatch time (HTTP fallback, command routing, single-flight per identity)
+- `runtime!` keys for resolver-backed deployments: `resolver:`,
+  `command_guest:`, `program:`, and compile-time `config:` fallback
+- Embedded guest bytes (`include_bytes!` / `Source::embedded`) for
+  single-binary hosts alongside path-sourced guests
+- Dynamic `Runtime::register` / `deregister` after bootstrap, including late
+  import polyfill for guests admitted after static assembly
+- Pooling allocator enabled by default, with environment-driven
+  `RuntimeOptions` shared by `omnia compile` and `omnia create`
+- `omnia-wasi-model` host interface and workspace packaging for model /
+  working-tree workflows
+- Stateless MCP stack in `omnia-guest` (JSON-RPC + Streamable HTTP) and
+  testkit helpers for MCP grant recording
+- Concurrent (`async func`) host-mediated link dispatch via
+  `func_new_concurrent` / `send_concurrent`
+- `omnia-testkit` (dev-only) and an integration-first testing posture
+
 ### Changed
+
+- `omnia-sdk` renamed to `omnia-guest`; host/guest macro crates split into
+  `omnia-host-macros` and `omnia-guest-macros`; `omnia-otel` folded into
+  `omnia`; `omnia-wasi-jsondb` replaced by `omnia-wasi-docstore`
+- Deployments center on `Manifest` / `omnia.toml` (`OMNIA_CONFIG`), with
+  `[[mount]]` working-tree preopens and typed `DeploymentBuilder` paths
+  (safe wasm vs trusted precompiled)
+- Upgraded `wasmtime` to 47.0.2 (and matching `wasmtime-wasi*`),
+  `wit-bindgen` to 0.60, `wasip3` to 0.7, and `cap-std` / `cap-fs-ext` to 4.x
+- Compile-affecting runtime toggles now include `DEBUG_SYMBOLS` and
+  `GENERATE_ADDRESS_MAP` so AOT compile and load stay aligned
 
 <!-- Release notes generated using configuration in .github/release.yaml at main -->
 
 ## What's Changed
-* Bump to 0.34.0 by @augentic-releases[bot] in https://github.com/augentic/omnia/pull/200
-* Sdk fixes by @karthik-phl in https://github.com/augentic/omnia/pull/201
 * Bump to 0.35.0 by @augentic-releases[bot] in https://github.com/augentic/omnia/pull/202
 * Instrumentation fix by @andrewweston in https://github.com/augentic/omnia/pull/203
 * Instance pooling by @andrewweston in https://github.com/augentic/omnia/pull/204
@@ -32,8 +62,7 @@ Unreleased
 * Embed guest bytes by @andrewweston in https://github.com/augentic/omnia/pull/220
 * Update to wasmtime 47.0.2 by @andrewweston in https://github.com/augentic/omnia/pull/221
 
-
-**Full Changelog**: https://github.com/augentic/omnia/compare/v0.33.0...v0.35.0
+**Full Changelog**: https://github.com/augentic/omnia/compare/v0.34.0...v0.35.0
 
 ---
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 ## 0.35.0
 
-Unreleased
+Released 2026-07-25
 
 ### Added
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,35 @@ Unreleased
 
 ### Changed
 
+<!-- Release notes generated using configuration in .github/release.yaml at main -->
+
+## What's Changed
+* Bump to 0.34.0 by @augentic-releases[bot] in https://github.com/augentic/omnia/pull/200
+* Sdk fixes by @karthik-phl in https://github.com/augentic/omnia/pull/201
+* Bump to 0.35.0 by @augentic-releases[bot] in https://github.com/augentic/omnia/pull/202
+* Instrumentation fix by @andrewweston in https://github.com/augentic/omnia/pull/203
+* Instance pooling by @andrewweston in https://github.com/augentic/omnia/pull/204
+* Guest registry by @andrewweston in https://github.com/augentic/omnia/pull/205
+* Implement wasi model by @andrewweston in https://github.com/augentic/omnia/pull/206
+* Specify readiness testing by @andrewweston in https://github.com/augentic/omnia/pull/207
+* MCP server for cursor-agent by @andrewweston in https://github.com/augentic/omnia/pull/208
+* Post-upgrade testing and code review by @andrewweston in https://github.com/augentic/omnia/pull/209
+* Async guest-2-guest linking by @andrewweston in https://github.com/augentic/omnia/pull/210
+* style fenced code by @andrewweston in https://github.com/augentic/omnia/pull/211
+* Specify-driven refactoring by @andrewweston in https://github.com/augentic/omnia/pull/212
+* Streamline testing by @andrewweston in https://github.com/augentic/omnia/pull/213
+* Replay by @andrewweston in https://github.com/augentic/omnia/pull/214
+* MCP grants by @andrewweston in https://github.com/augentic/omnia/pull/215
+* Runtime flexibility by @andrewweston in https://github.com/augentic/omnia/pull/216
+* improve runtime config by @andrewweston in https://github.com/augentic/omnia/pull/217
+* Dynamic guest resolver by @andrewweston in https://github.com/augentic/omnia/pull/218
+* Dynamic guest resolver in runtime! by @andrewweston in https://github.com/augentic/omnia/pull/219
+* Embed guest bytes by @andrewweston in https://github.com/augentic/omnia/pull/220
+* Update to wasmtime 47.0.2 by @andrewweston in https://github.com/augentic/omnia/pull/221
+
+
+**Full Changelog**: https://github.com/augentic/omnia/compare/v0.33.0...v0.35.0
+
 ---
 
 Release notes for previous releases can be found on the respective release branches of the repository.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to release notes; no runtime or application code is modified.
> 
> **Overview**
> **Publishes the 0.35.0 release entry** in `RELEASES.md`: marks the version as released on **2026-07-25** (replacing “Unreleased”) and adds the full **Added** / **Changed** notes for this train.
> 
> The new text captures the major themes from the merged work—multi-guest registry and resolve-on-miss `GuestResolver`, `runtime!` resolver keys and embedded guests, dynamic register/deregister, default pooling allocator, `omnia-wasi-model`, MCP in `omnia-guest`, async guest-to-guest linking, crate renames and manifest-centered deployments, and **wasmtime 47.0.2** / related dependency bumps—plus a **What’s Changed** section linking PRs #202–#221 and a **0.35.x** archive link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa892801c6b8b36059bee25d8ae3e5b977b8595d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->