### PR TITLE
Improve telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -900,9 +900,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "email_address"
@@ -1750,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.48.5"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05a6cff806294a7699d48761d4ae2bdebab7fa2eef05e4a0b83320f0ff46901"
+checksum = "9cc9116a0f75b7336e55eb2a2a0ddef86c37cadf02924a571751aa123d5a0290"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1779,18 +1779,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.48.5"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84708dd3f6c5327478a96f37378adb27deed6a626cf84d19de780d9e8ae84b17"
+checksum = "628a1f02bda4651d9a6088ee6386a92f0ee96255b0c99e9dfe1be91bf83bd838"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.48.5"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd8c04ab4ce60e42c4e302d3bd9d184652bb56f212495d2eea23573bcbf72556"
+checksum = "75d94a372f8d81d070fd405065c6b1168d8248d1d6adad073ac708de254698c6"
 dependencies = [
  "ahash",
  "bytecount",
@@ -3008,9 +3008,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.48.5"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980e77f5cfffc592c0e7dfb6d20770a0b96a6ab94d403de7454ed9799505e4ba"
+checksum = "978badf4419c9d0e1bc6e7466e99277f829d768257670c46d88121ca75e34bf7"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -3258,9 +3258,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -5241,7 +5241,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 [[package]]
 name = "wrpc-introspect"
 version = "0.7.0"
-source = "git+https://github.com/bytecodealliance/wrpc#f4e36b24517ffcb513a580b4a6a39d631003891e"
+source = "git+https://github.com/bytecodealliance/wrpc#52e5d7f13d5a1d9073bde734e01b27cd77202473"
 dependencies = [
  "wit-parser 0.251.0",
 ]
@@ -5249,7 +5249,7 @@ dependencies = [
 [[package]]
 name = "wrpc-transport"
 version = "0.29.0"
-source = "git+https://github.com/bytecodealliance/wrpc#f4e36b24517ffcb513a580b4a6a39d631003891e"
+source = "git+https://github.com/bytecodealliance/wrpc#52e5d7f13d5a1d9073bde734e01b27cd77202473"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5266,7 +5266,7 @@ dependencies = [
 [[package]]
 name = "wrpc-wasmtime"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wrpc#f4e36b24517ffcb513a580b4a6a39d631003891e"
+source = "git+https://github.com/bytecodealliance/wrpc#52e5d7f13d5a1d9073bde734e01b27cd77202473"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ hyper-util = "0.1.20"
 insta = "1.48.0"
 # Default features pull reqwest/rustls for remote `$ref` resolution; the gate
 # only validates self-contained schema documents.
-jsonschema = { version = "0.48.5", default-features = false }
+jsonschema = { version = "0.49.1", default-features = false }
 moka = { version = "0.12.15", features = ["sync"] }
 opentelemetry = "0.32.0"
 opentelemetry-proto = "0.32.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://augentic.io"
 keywords = ["runtime", "wasi", "wasm", "wasmtime", "component-model"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/augentic/omnia"
-rust-version = "1.95"
+rust-version = "1.97"
 version = "0.35.0"
 
 [workspace.lints.rust]

--- a/crates/omnia/README.md
+++ b/crates/omnia/README.md
@@ -77,7 +77,7 @@ Telemetry::new("my-service")
     .build()?;
 ```
 
-Initialization is idempotent: the first `build` in the process installs the subscriber and providers, and later calls are no-ops that reuse them, so an embedder initializing telemetry itself and the runtime's own startup never conflict. Telemetry is batch-exported; the runtime flushes it at the end of every run so it survives fast command-mode exits, and embedders driving work themselves can call `omnia::flush_telemetry()` before the process exits. The `OTEL_GRPC_URL` environment variable is respected when set; when unset, OpenTelemetry defaults apply. When no collector is running, silence export errors with `RUST_LOG=...,opentelemetry_sdk=off`.
+Initialization is idempotent: the first `build` in the process installs the subscriber and providers, and later calls are no-ops that reuse them, so an embedder initializing telemetry itself and the runtime's own startup never conflict. Telemetry is batch-exported; the runtime flushes it at the end of every run so it survives fast command-mode exits, and embedders driving work themselves can call `omnia::telemetry::flush()` before the process exits. The `OTEL_GRPC_URL` environment variable is respected when set; when unset, OpenTelemetry defaults apply. When no collector is running, silence export errors with `RUST_LOG=...,opentelemetry_sdk=off`.
 
 ## Architecture
 

--- a/crates/omnia/README.md
+++ b/crates/omnia/README.md
@@ -77,7 +77,7 @@ Telemetry::new("my-service")
     .build()?;
 ```
 
-The `OTEL_GRPC_URL` environment variable is respected when set; when unset, OpenTelemetry defaults apply. When no collector is running, silence export errors with `RUST_LOG=...,opentelemetry_sdk=off`.
+Initialization is idempotent: the first `build` in the process installs the subscriber and providers, and later calls are no-ops that reuse them, so an embedder initializing telemetry itself and the runtime's own startup never conflict. Telemetry is batch-exported; the runtime flushes it at the end of every run so it survives fast command-mode exits, and embedders driving work themselves can call `omnia::flush_telemetry()` before the process exits. The `OTEL_GRPC_URL` environment variable is respected when set; when unset, OpenTelemetry defaults apply. When no collector is running, silence export errors with `RUST_LOG=...,opentelemetry_sdk=off`.
 
 ## Architecture
 

--- a/crates/omnia/src/deployment.rs
+++ b/crates/omnia/src/deployment.rs
@@ -476,12 +476,10 @@ fn engine_and_linker<T: WasiView + 'static>() -> Result<(Engine, Linker<T>, Runt
 
 // Initialize telemetry and the `COMPONENT` environment variable for the runtime.
 //
-// Telemetry (a process-global tracing subscriber) initializes once; later
-// deployments in the same process — embedders or a multi-deployment test
-// suite — reuse the first initialization.
+// Telemetry initialization is idempotent (`Telemetry::build`): the first call
+// in the process — here or in an embedder — installs the subscriber and
+// providers, and later deployments reuse them.
 fn init_env(name: &str) -> Result<()> {
-    static TELEMETRY: std::sync::OnceLock<()> = std::sync::OnceLock::new();
-
     if env::var_os("COMPONENT").is_none() {
         // SAFETY: Environment variable modification is safe here because:
         // 1. This runs during single-threaded initialization
@@ -489,10 +487,6 @@ fn init_env(name: &str) -> Result<()> {
         unsafe {
             env::set_var("COMPONENT", name);
         };
-    }
-
-    if TELEMETRY.set(()).is_err() {
-        return Ok(());
     }
 
     let mut builder = Telemetry::new(name);

--- a/crates/omnia/src/lib.rs
+++ b/crates/omnia/src/lib.rs
@@ -11,7 +11,7 @@ mod options;
 mod registry;
 mod runtime;
 mod store;
-mod telemetry;
+pub mod telemetry;
 
 pub use clap::Parser;
 pub use omnia_host_macros::runtime;
@@ -45,7 +45,7 @@ pub use self::runtime::{MainOptions, ManifestSource, main, run, run_precompiled}
 pub use self::store::{
     HasDispatcher, HasHttp, HasLimits, HasMounts, StoreBase, StoreBaseBuilder, StoreCtx,
 };
-pub use self::telemetry::{Telemetry, flush as flush_telemetry, resource};
+pub use self::telemetry::Telemetry;
 
 /// Generates the standard host-error conversions every `omnia` WASI host
 /// crate repeats.

--- a/crates/omnia/src/lib.rs
+++ b/crates/omnia/src/lib.rs
@@ -45,7 +45,7 @@ pub use self::runtime::{MainOptions, ManifestSource, main, run, run_precompiled}
 pub use self::store::{
     HasDispatcher, HasHttp, HasLimits, HasMounts, StoreBase, StoreBaseBuilder, StoreCtx,
 };
-pub use self::telemetry::{Telemetry, resource};
+pub use self::telemetry::{Telemetry, flush as flush_telemetry, resource};
 
 /// Generates the standard host-error conversions every `omnia` WASI host
 /// crate repeats.

--- a/crates/omnia/src/runtime.rs
+++ b/crates/omnia/src/runtime.rs
@@ -212,6 +212,9 @@ where
     if let Some(pool) = pool {
         pool.abort();
     }
+    // Push batch-queued spans and metrics to the exporters so they survive
+    // fast command-mode exits.
+    crate::telemetry::flush();
     outcome
 }
 

--- a/crates/omnia/src/telemetry.rs
+++ b/crates/omnia/src/telemetry.rs
@@ -25,14 +25,14 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Registry};
 
-static RESOURCE: OnceLock<Resource> = OnceLock::new();
+// The process's telemetry state. Like the global subscriber that references
+// the providers, it lives for the rest of the process.
+static INSTALLED: OnceLock<Installed> = OnceLock::new();
 
-// The process's provider handles, kept for flushing. Like the global
-// subscriber that references them, they live for the rest of the process.
-static PROVIDERS: OnceLock<Providers> = OnceLock::new();
-
-// Serializes first-time initialization so concurrent builds cannot race
-// between the reuse check and provider installation.
+// Serializes first-time initialization. The `OnceLock` alone cannot: `build`
+// is fallible (ruling out `get_or_init`), and without this a losing racer
+// would already have installed the global providers and failed `try_init`
+// before discovering it lost.
 static INIT: Mutex<()> = Mutex::new(());
 
 const UNKNOWN: &str = "unknown";
@@ -90,19 +90,18 @@ impl Telemetry {
     /// subscriber fails.
     pub fn build(self) -> Result<()> {
         let _init = INIT.lock().unwrap_or_else(PoisonError::into_inner);
-        if PROVIDERS.get().is_some() {
+        if INSTALLED.get().is_some() {
             return Ok(());
         }
 
         let resource = self.resource();
-        RESOURCE.set(resource.clone()).map_err(|r| anyhow!("failed to set resource: {r:?}"))?;
 
         // metrics
         let meter_provider = self.build_metrics(resource.clone())?;
         global::set_meter_provider(meter_provider.clone());
 
         // tracing
-        let tracer_provider = self.build_traces(resource)?;
+        let tracer_provider = self.build_traces(resource.clone())?;
         global::set_tracer_provider(tracer_provider.clone());
 
         let filter_layer = EnvFilter::from_default_env()
@@ -124,12 +123,13 @@ impl Telemetry {
             .with(metrics_layer)
             .try_init()?;
 
-        PROVIDERS
-            .set(Providers {
+        INSTALLED
+            .set(Installed {
+                resource,
                 tracer: tracer_provider,
                 meter: meter_provider,
             })
-            .map_err(|_providers| anyhow!("telemetry providers already installed"))
+            .map_err(|_installed| anyhow!("telemetry providers already installed"))
     }
 
     fn build_traces(&self, resource: Resource) -> Result<SdkTracerProvider> {
@@ -177,19 +177,18 @@ impl Telemetry {
     }
 }
 
-// The process's provider handles.
-struct Providers {
+// The process's resource and provider handles.
+struct Installed {
+    resource: Resource,
     tracer: SdkTracerProvider,
     meter: SdkMeterProvider,
 }
 
-impl Providers {
-    // Force-flush (not shut down) both providers, so telemetry keeps
-    // exporting afterwards and repeated flushes are safe.
-    fn flush(&self) {
-        settle("traces", self.tracer.force_flush());
-        settle("metrics", self.meter.force_flush());
-    }
+// Force-flush (not shut down) both providers, so telemetry keeps exporting
+// afterwards and repeated flushes are safe.
+fn flush_providers(tracer: &SdkTracerProvider, meter: &SdkMeterProvider) {
+    settle("traces", tracer.force_flush());
+    settle("metrics", meter.force_flush());
 }
 
 // Report a flush failure without panicking; a provider that is already shut
@@ -203,20 +202,21 @@ fn settle(signal: &str, result: OTelSdkResult) {
 
 /// Flush batched telemetry to the exporters.
 ///
-/// A no-op when telemetry was never initialized. Export continues afterwards,
-/// so call it freely — the runtime calls it at the end of every drive so
-/// queued spans and metrics survive fast command-mode exits; embedders driving
-/// work themselves should call it before the process exits.
+/// A no-op when telemetry was never initialized. This force-flushes rather
+/// than shutting down, so export continues afterwards and repeated flushes
+/// are safe — the runtime calls it at the end of every drive so queued spans
+/// and metrics survive fast command-mode exits; embedders driving work
+/// themselves should call it before the process exits.
 pub fn flush() {
-    if let Some(providers) = PROVIDERS.get() {
-        providers.flush();
+    if let Some(installed) = INSTALLED.get() {
+        flush_providers(&installed.tracer, &installed.meter);
     }
 }
 
 /// Returns the OpenTelemetry [`Resource`] used to initialize telemetry for a
 /// service, or `None` if telemetry has not been initialized.
 pub fn resource() -> Option<&'static Resource> {
-    RESOURCE.get()
+    INSTALLED.get().map(|installed| &installed.resource)
 }
 
 #[cfg(test)]
@@ -227,7 +227,7 @@ mod tests {
     use opentelemetry_sdk::metrics::SdkMeterProvider;
     use opentelemetry_sdk::trace::{SdkTracerProvider, SpanData, SpanExporter};
 
-    use super::{OTelSdkResult, Providers};
+    use super::{OTelSdkResult, flush_providers};
 
     // A span exporter that keeps its records, so flushing is observable
     // without a collector.
@@ -254,15 +254,11 @@ mod tests {
 
     // A batch-exported provider set: spans stay queued (5s schedule delay)
     // until a flush pushes them, so flush behavior is what the test sees.
-    fn providers(exporter: &Recording) -> Providers {
-        Providers {
-            tracer: SdkTracerProvider::builder().with_batch_exporter(exporter.clone()).build(),
-            meter: SdkMeterProvider::builder().build(),
-        }
-    }
-
-    fn emit(providers: &Providers, name: &'static str) {
-        providers.tracer.tracer("test").start(name);
+    fn providers(exporter: &Recording) -> (SdkTracerProvider, SdkMeterProvider) {
+        (
+            SdkTracerProvider::builder().with_batch_exporter(exporter.clone()).build(),
+            SdkMeterProvider::builder().build(),
+        )
     }
 
     // The fast-exit contract: a span emitted immediately before a flush
@@ -270,16 +266,16 @@ mod tests {
     #[test]
     fn flush_exports_queued_spans() {
         let exporter = Recording::default();
-        let providers = providers(&exporter);
+        let (tracer, meter) = providers(&exporter);
 
-        emit(&providers, "first-drive");
+        tracer.tracer("test").start("first-drive");
         assert!(exporter.names().is_empty());
 
-        providers.flush();
+        flush_providers(&tracer, &meter);
         assert_eq!(exporter.names(), ["first-drive"]);
 
-        emit(&providers, "second-drive");
-        providers.flush();
+        tracer.tracer("test").start("second-drive");
+        flush_providers(&tracer, &meter);
         assert_eq!(exporter.names(), ["first-drive", "second-drive"]);
     }
 }

--- a/crates/omnia/src/telemetry.rs
+++ b/crates/omnia/src/telemetry.rs
@@ -2,15 +2,22 @@
 //!
 //! Host-side OpenTelemetry initialization and OTLP exporters used to report
 //! runtime telemetry out-of-the-box.
+//!
+//! The providers are process-global: the first [`Telemetry::build`] installs
+//! them along with the global tracing subscriber, and later builds in the
+//! same process are no-ops that reuse the first initialization. Batch
+//! exporters queue telemetry, so call [`flush`] before a fast process exit;
+//! the runtime does this at the end of every drive.
 
 use std::env;
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock, PoisonError};
 
 use anyhow::{Result, anyhow};
 use opentelemetry::trace::TracerProvider;
 use opentelemetry::{KeyValue, global};
 use opentelemetry_otlp::{MetricExporter, SpanExporter, WithExportConfig};
 use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use tracing_opentelemetry::MetricsLayer;
@@ -19,6 +26,14 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Registry};
 
 static RESOURCE: OnceLock<Resource> = OnceLock::new();
+
+// The process's provider handles, kept for flushing. Like the global
+// subscriber that references them, they live for the rest of the process.
+static PROVIDERS: OnceLock<Providers> = OnceLock::new();
+
+// Serializes first-time initialization so concurrent builds cannot race
+// between the reuse check and provider installation.
+static INIT: Mutex<()> = Mutex::new(());
 
 const UNKNOWN: &str = "unknown";
 
@@ -63,12 +78,22 @@ impl Telemetry {
 
     /// Initializes telemetry using the provided configuration.
     ///
+    /// The first call in the process installs the global subscriber and
+    /// providers; later calls are no-ops that reuse them (this builder's
+    /// configuration is ignored), so embedders and the runtime can each
+    /// initialize without coordinating.
+    ///
     /// # Errors
     ///
     /// Returns an error if the telemetry system fails to initialize, such as if
     /// the OpenTelemetry exporter cannot be created or if setting the global
     /// subscriber fails.
     pub fn build(self) -> Result<()> {
+        let _init = INIT.lock().unwrap_or_else(PoisonError::into_inner);
+        if PROVIDERS.get().is_some() {
+            return Ok(());
+        }
+
         let resource = self.resource();
         RESOURCE.set(resource.clone()).map_err(|r| anyhow!("failed to set resource: {r:?}"))?;
 
@@ -89,7 +114,7 @@ impl Telemetry {
         let fmt_layer = tracing_subscriber::fmt::layer();
         let tracer = tracer_provider.tracer(self.app_name);
         let tracing_layer = tracing_opentelemetry::layer().with_tracer(tracer);
-        let metrics_layer = MetricsLayer::new(meter_provider);
+        let metrics_layer = MetricsLayer::new(meter_provider.clone());
 
         // set global default subscriber
         Registry::default()
@@ -99,7 +124,12 @@ impl Telemetry {
             .with(metrics_layer)
             .try_init()?;
 
-        Ok(())
+        PROVIDERS
+            .set(Providers {
+                tracer: tracer_provider,
+                meter: meter_provider,
+            })
+            .map_err(|_providers| anyhow!("telemetry providers already installed"))
     }
 
     fn build_traces(&self, resource: Resource) -> Result<SdkTracerProvider> {
@@ -147,8 +177,109 @@ impl Telemetry {
     }
 }
 
+// The process's provider handles.
+struct Providers {
+    tracer: SdkTracerProvider,
+    meter: SdkMeterProvider,
+}
+
+impl Providers {
+    // Force-flush (not shut down) both providers, so telemetry keeps
+    // exporting afterwards and repeated flushes are safe.
+    fn flush(&self) {
+        settle("traces", self.tracer.force_flush());
+        settle("metrics", self.meter.force_flush());
+    }
+}
+
+// Report a flush failure without panicking; a provider that is already shut
+// down has nothing left to flush.
+fn settle(signal: &str, result: OTelSdkResult) {
+    match result {
+        Ok(()) | Err(OTelSdkError::AlreadyShutdown) => {}
+        Err(error) => tracing::warn!(%error, "telemetry: {signal} flush failed"),
+    }
+}
+
+/// Flush batched telemetry to the exporters.
+///
+/// A no-op when telemetry was never initialized. Export continues afterwards,
+/// so call it freely — the runtime calls it at the end of every drive so
+/// queued spans and metrics survive fast command-mode exits; embedders driving
+/// work themselves should call it before the process exits.
+pub fn flush() {
+    if let Some(providers) = PROVIDERS.get() {
+        providers.flush();
+    }
+}
+
 /// Returns the OpenTelemetry [`Resource`] used to initialize telemetry for a
 /// service, or `None` if telemetry has not been initialized.
 pub fn resource() -> Option<&'static Resource> {
     RESOURCE.get()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use opentelemetry::trace::{Tracer as _, TracerProvider as _};
+    use opentelemetry_sdk::metrics::SdkMeterProvider;
+    use opentelemetry_sdk::trace::{SdkTracerProvider, SpanData, SpanExporter};
+
+    use super::{OTelSdkResult, Providers};
+
+    // A span exporter that keeps its records, so flushing is observable
+    // without a collector.
+    #[derive(Clone, Debug, Default)]
+    struct Recording {
+        names: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl Recording {
+        fn names(&self) -> Vec<String> {
+            self.names.lock().expect("recording lock").clone()
+        }
+    }
+
+    impl SpanExporter for Recording {
+        async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+            self.names
+                .lock()
+                .expect("recording lock")
+                .extend(batch.into_iter().map(|span| span.name.into_owned()));
+            Ok(())
+        }
+    }
+
+    // A batch-exported provider set: spans stay queued (5s schedule delay)
+    // until a flush pushes them, so flush behavior is what the test sees.
+    fn providers(exporter: &Recording) -> Providers {
+        Providers {
+            tracer: SdkTracerProvider::builder().with_batch_exporter(exporter.clone()).build(),
+            meter: SdkMeterProvider::builder().build(),
+        }
+    }
+
+    fn emit(providers: &Providers, name: &'static str) {
+        providers.tracer.tracer("test").start(name);
+    }
+
+    // The fast-exit contract: a span emitted immediately before a flush
+    // reaches the exporter, and export keeps working after the flush.
+    #[test]
+    fn flush_exports_queued_spans() {
+        let exporter = Recording::default();
+        let providers = providers(&exporter);
+
+        emit(&providers, "first-drive");
+        assert!(exporter.names().is_empty());
+
+        providers.flush();
+        assert_eq!(exporter.names(), ["first-drive"]);
+
+        emit(&providers, "second-drive");
+        providers.flush();
+        assert_eq!(exporter.names(), ["first-drive", "second-drive"]);
+    }
 }

--- a/crates/wasi-otel/src/host/metrics_impl.rs
+++ b/crates/wasi-otel/src/host/metrics_impl.rs
@@ -27,7 +27,7 @@ impl<T> HostWithStore<T> for WasiOtel {
         accessor: &Accessor<T, Self>, rm: wasi::ResourceMetrics,
     ) -> Result<(), wasi::Error> {
         // return if opentelemetry is not initialized
-        if omnia::resource().is_none() {
+        if omnia::telemetry::resource().is_none() {
             tracing::warn!("otel resource not initialized, skipping metrics export");
             return Ok(());
         }

--- a/crates/wasi-otel/src/host/resource_impl.rs
+++ b/crates/wasi-otel/src/host/resource_impl.rs
@@ -5,7 +5,7 @@ use crate::host::generated::omnia::otel::{resource, types};
 
 impl resource::Host for WasiOtelCtxView<'_> {
     fn resource(&mut self) -> wasmtime::Result<types::Resource> {
-        let Some(resource) = omnia::resource() else {
+        let Some(resource) = omnia::telemetry::resource() else {
             ::tracing::warn!("otel resource not initialized");
             let empty = &Resource::builder().build();
             return Ok(empty.into());

--- a/crates/wasi-otel/src/host/tracing_impl.rs
+++ b/crates/wasi-otel/src/host/tracing_impl.rs
@@ -22,7 +22,7 @@ impl<T> HostWithStore<T> for WasiOtel {
         accessor: &Accessor<T, Self>, mut span_data: Vec<wasi::SpanData>,
     ) -> Result<(), wasi::Error> {
         // return if opentelemetry is not initialized
-        let Some(resource) = omnia::resource() else {
+        let Some(resource) = omnia::telemetry::resource() else {
             tracing::warn!("otel resource not initialized, skipping trace export");
             return Ok(());
         };

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -83,7 +83,7 @@ version = "0.6.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.cc]]
-version = "1.3.0"
+version = "1.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.chacha20]]
@@ -204,6 +204,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.displaydoc]]
 version = "0.2.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.either]]
+version = "1.17.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.email_address]]
@@ -415,15 +419,15 @@ version = "0.3.103"
 criteria = "safe-to-deploy"
 
 [[exemptions.jsonschema]]
-version = "0.48.5"
+version = "0.49.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.jsonschema-regex]]
-version = "0.48.5"
+version = "0.49.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.jsonschema-value]]
-version = "0.48.5"
+version = "0.49.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.leb128]]
@@ -627,7 +631,7 @@ version = "0.5.18"
 criteria = "safe-to-deploy"
 
 [[exemptions.referencing]]
-version = "0.48.5"
+version = "0.49.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.ring]]
@@ -655,7 +659,7 @@ version = "0.8.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls-pki-types]]
-version = "1.15.0"
+version = "1.15.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls-platform-verifier]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1874,34 +1874,6 @@ version = "0.8.7"
 notes = "OSX system APIs"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.either]]
-who = "Manish Goregaokar <manishearth@google.com>"
-criteria = "safe-to-deploy"
-version = "1.13.0"
-notes = "Unsafe code pertaining to wrapping Pin APIs. Mostly passes invariants down."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.either]]
-who = "Daniel Cheng <dcheng@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.13.0 -> 1.14.0"
-notes = """
-Inheriting ub-risk-1 from the baseline review of 1.13.0. While the delta has some diffs in unsafe code, they are either:
-- migrating code to use helper macros
-- migrating match patterns to take advantage of default bindings mode from RFC 2005
-Either way, the result is code that does exactly the same thing and does not change the risk of UB.
-
-See https://crrev.com/c/6323164 for more audit details.
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.either]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.14.0 -> 1.15.0"
-notes = 'The delta in `lib.rs` only tweaks doc comments and `#[cfg(feature = "std")]`.'
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
 [[audits.google.audits.equivalent]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
@@ -2267,12 +2239,6 @@ who = "Lars Eggert <lars@eggert.org>"
 criteria = "safe-to-deploy"
 delta = "0.4.0 -> 0.5.8"
 notes = "New unsafe code is properly guarded"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.either]]
-who = "Erich Gubler <erichdongubler@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "1.15.0 -> 1.16.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.fallible-iterator]]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are confined to telemetry initialization/export behavior and dependency bumps; no auth, security, or data-model changes beyond safer concurrent OTel setup.
> 
> **Overview**
> **OpenTelemetry lifecycle** is reworked so embedders and the runtime can both call `Telemetry::build` safely: the first call installs global providers and the tracing subscriber; later calls are no-ops. A mutex guards concurrent first-time init. Deployment no longer uses a separate `OnceLock` to skip telemetry—the behavior lives in `Telemetry::build` itself.
> 
> **Batch export** is addressed with a new **`omnia::telemetry::flush()`** that force-flushes traces and metrics (without shutting down). The runtime calls it at the end of every `drive`, so short command-mode runs still export queued telemetry. **`telemetry`** is now a **`pub mod`**; **`resource()`** stays on that module (crate root no longer re-exports it). WASI otel hosts use **`omnia::telemetry::resource()`**.
> 
> Docs in **`crates/omnia/README.md`** describe idempotent init, automatic flush, and embedder use of `flush()`. A unit test asserts flush exports queued spans.
> 
> **Toolchain and dependencies:** workspace **`rust-version`** 1.95 → **1.97**; **`jsonschema`** 0.48.5 → **0.49.1**; **`wrpc`** git pin updated; **`Cargo.lock`** and **cargo-vet** exemptions/imports adjusted for bumped crates (e.g. `cc`, `either`, `rustls-pki-types`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62157b854e1788984534b35c125a84091e7a12e6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->