### PR TITLE
Model answer

### DIFF
--- a/crates/wasi-model/src/host/answer.rs
+++ b/crates/wasi-model/src/host/answer.rs
@@ -1,6 +1,7 @@
 //! Answer parsing, validation, projection, and repair behavior shared by the
 //! host gate and backends.
 
+use serde::Deserialize as _;
 use serde_json::Value;
 
 use crate::host::Error;
@@ -31,13 +32,18 @@ impl Format {
 
     /// Interpret a model's text turn as an answer value.
     ///
+    /// For JSON / schema answers, tolerates a wrapping Markdown fence and —
+    /// when the model prepends agent prose — an embedded fence or the first
+    /// complete JSON value in the turn. Schema conformance is still enforced
+    /// by [`Self::check`].
+    ///
     /// # Errors
     ///
     /// Returns a repair reason when the text does not match this format.
     pub fn parse(&self, text: &str) -> Result<Value, String> {
         match self {
             Self::Text => Ok(Value::String(text.to_owned())),
-            Self::Json | Self::Schema(_) => serde_json::from_str::<Value>(strip_fence(text))
+            Self::Json | Self::Schema(_) => into_json(text)
                 .map_err(|error| format!("the answer was not valid JSON: {error}")),
         }
     }
@@ -75,14 +81,42 @@ impl Format {
     }
 }
 
-// Strip a wrapping Markdown code fence (```json ... ```), if present.
-fn strip_fence(text: &str) -> &str {
+/// Parse a JSON answer, accepting raw JSON, a leading or embedded Markdown
+/// fence, or a JSON value preceded / followed by agent prose.
+fn into_json(text: &str) -> Result<Value, serde_json::Error> {
     let trimmed = text.trim();
-    let Some(rest) = trimmed.strip_prefix("```") else {
-        return trimmed;
+
+    // 1. Whole text as-is.
+    if let Ok(value) = serde_json::from_str(trimmed) {
+        return Ok(value);
+    }
+
+    // 2. Fence anywhere (agent preamble + ```json … ```), closed or not.
+    if let Some(body) = fence_body(trimmed)
+        && let Ok(value) = serde_json::from_str(body)
+    {
+        return Ok(value);
+    }
+
+    // 3. First complete JSON value at the first `{` or `[`.
+       let Some(offset) = text.find(['{', '[']) else {
+        return serde_json::from_str(text);
     };
-    let body = rest.split_once('\n').map_or(rest, |(_, body)| body).trim();
-    body.strip_suffix("```").unwrap_or(body).trim()
+
+    // HACK: serde_json::from_str(&text[offset..]) doesn't work without knowing
+    // the location of the matching close brace
+    let mut de = serde_json::Deserializer::from_str(&text[offset..]);
+    Value::deserialize(&mut de)
+}
+
+// Body of the first Markdown fence in `text`, if any; an unterminated fence
+// yields the remainder of the text.
+fn fence_body(text: &str) -> Option<&str> {
+    let start = text.find("```")?;
+    let rest = &text[start + 3..];
+    let body = rest.split_once('\n').map_or(rest, |(_, body)| body);
+    let body = body.find("```").map_or(body, |end| &body[..end]);
+    Some(body.trim())
 }
 
 impl Answer {
@@ -157,6 +191,30 @@ mod tests {
     fn code_fence_stripped() {
         let fenced = "```json\n{\"verdict\":\"pass\"}\n```";
         assert_eq!(verdict_schema().parse(fenced).unwrap(), json!({ "verdict": "pass" }));
+    }
+
+    #[test]
+    fn preamble_then_fence() {
+        let text = "Let me synthesize.\n```json\n{\"verdict\":\"pass\"}\n```";
+        assert_eq!(Format::Json.parse(text).unwrap(), json!({ "verdict": "pass" }));
+    }
+
+    #[test]
+    fn preamble_then_raw_object() {
+        let text = "Done.\n{\"verdict\":\"pass\"}\n";
+        assert_eq!(Format::Json.parse(text).unwrap(), json!({ "verdict": "pass" }));
+    }
+
+    #[test]
+    fn trailing_prose_after_object() {
+        let text = "{\"verdict\":\"pass\"}\nthanks";
+        assert_eq!(Format::Json.parse(text).unwrap(), json!({ "verdict": "pass" }));
+    }
+
+    #[test]
+    fn still_rejects_non_json() {
+        let err = Format::Json.parse("no braces here").unwrap_err();
+        assert!(err.contains("not valid JSON"), "unexpected: {err}");
     }
 
     #[test]

--- a/crates/wasi-model/src/host/answer.rs
+++ b/crates/wasi-model/src/host/answer.rs
@@ -43,8 +43,9 @@ impl Format {
     pub fn parse(&self, text: &str) -> Result<Value, String> {
         match self {
             Self::Text => Ok(Value::String(text.to_owned())),
-            Self::Json | Self::Schema(_) => into_json(text)
-                .map_err(|error| format!("the answer was not valid JSON: {error}")),
+            Self::Json | Self::Schema(_) => {
+                into_json(text).map_err(|err| format!("answer is not valid JSON: {err}"))
+            }
         }
     }
 
@@ -92,31 +93,25 @@ fn into_json(text: &str) -> Result<Value, serde_json::Error> {
     }
 
     // 2. Fence anywhere (agent preamble + ```json … ```), closed or not.
-    if let Some(body) = fence_body(trimmed)
-        && let Ok(value) = serde_json::from_str(body)
-    {
+    if let Some(value) = from_fenced(trimmed) {
         return Ok(value);
     }
 
     // 3. First complete JSON value at the first `{` or `[`.
-       let Some(offset) = text.find(['{', '[']) else {
-        return serde_json::from_str(text);
-    };
-
-    // HACK: serde_json::from_str(&text[offset..]) doesn't work without knowing
-    // the location of the matching close brace
-    let mut de = serde_json::Deserializer::from_str(&text[offset..]);
+    let offset = trimmed.find(['{', '[']).unwrap_or(0);
+    // parse one value, ignoring any trailing text after closing `}` or `]`
+    let mut de = serde_json::Deserializer::from_str(&trimmed[offset..]);
     Value::deserialize(&mut de)
 }
 
 // Body of the first Markdown fence in `text`, if any; an unterminated fence
 // yields the remainder of the text.
-fn fence_body(text: &str) -> Option<&str> {
+fn from_fenced(text: &str) -> Option<Value> {
     let start = text.find("```")?;
     let rest = &text[start + 3..];
     let body = rest.split_once('\n').map_or(rest, |(_, body)| body);
     let body = body.find("```").map_or(body, |end| &body[..end]);
-    Some(body.trim())
+    serde_json::from_str(body.trim()).ok()
 }
 
 impl Answer {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized parsing logic in the WASI model host with added tests; validation and repair paths are unchanged aside from accepting more parseable inputs.
> 
> **Overview**
> **JSON / schema answer parsing** in `answer.rs` is more tolerant of real model output. `Format::parse` no longer relies on stripping only a leading Markdown fence; it uses `into_json`, which tries the full trimmed string, then the first fenced block (including preamble + ` ```json ` and unclosed fences), then the first complete JSON value from the first `{` or `[` via a streaming deserializer (so trailing prose after a closing `}` / `]` is ignored).
> 
> **Schema validation is unchanged** — `Format::check` still enforces object shape and JSON Schema. Parse errors are slightly reworded (`answer is not valid JSON`).
> 
> New unit tests cover preamble + fence, preamble + raw object, trailing prose, and non-JSON rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d1e688e118eaafdac0d35884da2eb643711253d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->