### PR TITLE
remove timeout wrapper on CLI

### DIFF
--- a/crates/omnia/src/options.rs
+++ b/crates/omnia/src/options.rs
@@ -48,7 +48,7 @@ use wasmtime::{Config, Enabled, InstanceAllocationStrategy, PoolingAllocationCon
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, FromEnv)]
 pub struct RuntimeOptions {
-    /// Wall-clock cap on a single guest invocation (`GUEST_TIMEOUT_MS`, default 30s).
+    /// Wall-clock cap on a server or link-dispatch invocation (`GUEST_TIMEOUT_MS`, default 30s; command mode uncapped).
     #[env(from = "GUEST_TIMEOUT_MS", default = "30000", with = parse_millis)]
     pub guest_timeout: Duration,
     /// Epoch-increment interval, also the CPU-bound guest yield granularity (`EPOCH_TICK_MS`, default 10ms, min 1ms).

--- a/crates/omnia/src/runtime/command.rs
+++ b/crates/omnia/src/runtime/command.rs
@@ -22,8 +22,8 @@ use crate::store::StoreCtx;
 /// # Errors
 ///
 /// Returns an error if the explicit command guest cannot be ensured, routing
-/// is ambiguous, the guest cannot be instantiated, the run exceeds
-/// `guest_timeout`, or the command traps without a guest exit code.
+/// is ambiguous, the guest cannot be instantiated, or the command traps
+/// without a guest exit code.
 pub(super) async fn drive<B>(runtime: &Runtime<B>) -> Result<ExitStatus>
 where
     B: Clone + Send + Sync + 'static,
@@ -70,13 +70,9 @@ where
     let instance = runtime.instantiate(guest.instance_pre(), &mut store).await?;
     let command = Command::new(&mut store, &instance)?;
 
-    // The same wall-clock bound every other trigger applies to guest work;
-    // long-running commands raise GUEST_TIMEOUT_MS.
-    let timeout = runtime.options().guest_timeout;
-    let run = store.run_concurrent(async move |store| command.wasi_cli_run().call_run(store).await);
-    let outcome = tokio::time::timeout(timeout, run)
-        .await
-        .map_err(|_elapsed| anyhow::anyhow!("wasi:cli/run timed out after {timeout:?}"))?;
+    let outcome = store
+        .run_concurrent(async move |store| command.wasi_cli_run().call_run(store).await)
+        .await;
 
     let status = match outcome {
         Ok(Ok(Ok(()))) => ExitStatus::SUCCESS,

--- a/crates/omnia/src/runtime/command.rs
+++ b/crates/omnia/src/runtime/command.rs
@@ -70,9 +70,8 @@ where
     let instance = runtime.instantiate(guest.instance_pre(), &mut store).await?;
     let command = Command::new(&mut store, &instance)?;
 
-    let outcome = store
-        .run_concurrent(async move |store| command.wasi_cli_run().call_run(store).await)
-        .await;
+    let outcome =
+        store.run_concurrent(async move |store| command.wasi_cli_run().call_run(store).await).await;
 
     let status = match outcome {
         Ok(Ok(Ok(()))) => ExitStatus::SUCCESS,

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -183,7 +183,7 @@ CLI → Build → Runtime::new → bootstrap → run
 
 ### Isolation and pooling
 
-Every invocation gets a **fresh instance in its own store** — no state survives between requests, and guests cannot observe each other except through host-mediated dispatch. To keep this cheap, the pooling instance allocator (on by default, `POOLING=true`) recycles instance slots; guest resource ceilings (`GUEST_TIMEOUT_MS`, `MAX_MEMORY_BYTES`, `MAX_FUEL`) bound each invocation. See [Configuration](reference/configuration.md) for the tunables.
+Every invocation gets a **fresh instance in its own store** — no state survives between requests, and guests cannot observe each other except through host-mediated dispatch. To keep this cheap, the pooling instance allocator (on by default, `POOLING=true`) recycles instance slots; guest resource ceilings (`GUEST_TIMEOUT_MS` for server/dispatch, `MAX_MEMORY_BYTES`, `MAX_FUEL`) bound each invocation. See [Configuration](reference/configuration.md) for the tunables.
 
 ## Configuration
 

--- a/docs/guides/composing-a-runtime.md
+++ b/docs/guides/composing-a-runtime.md
@@ -42,7 +42,7 @@ cargo run -- run ./path/to/guest.wasm
 The optional `mode` key selects how the runtime drives guests:
 
 - **`mode: server`** (the default) — the runtime stays up and serves requests. Trigger hosts (`WasiHttp`, `WasiMessaging`, `WasiWebSocket`) listen for traffic and instantiate a fresh guest instance per request.
-- **`mode: command`** — the runtime drives the guest's `wasi:cli/run` export exactly once, then exits with the guest's status. Use this for jobs, CLIs, and agent tasks.
+- **`mode: command`** — the runtime drives the guest's `wasi:cli/run` export exactly once, then exits with the guest's status. Use this for jobs, CLIs, and agent tasks. Unlike server triggers, command mode applies no `GUEST_TIMEOUT_MS` wall-clock cap.
 
 ```rust
 omnia::runtime!({

--- a/docs/guides/performance-tuning.md
+++ b/docs/guides/performance-tuning.md
@@ -53,7 +53,7 @@ Per-request tuning doesn't help cold starts. For those, pre-compile guests (`com
 
 ## Limits that interact with latency
 
-- `GUEST_TIMEOUT_MS` (default 30s) bounds each invocation wall-clock; `EPOCH_TICK_MS` (default 10ms) is the granularity at which CPU-bound guests yield and timeouts are enforced. Lowering the tick tightens timeout precision at slight overhead.
+- `GUEST_TIMEOUT_MS` (default 30s) bounds each server/dispatch invocation wall-clock (command mode is uncapped); `EPOCH_TICK_MS` (default 10ms) is the granularity at which CPU-bound guests yield and timeouts are enforced. Lowering the tick tightens timeout precision at slight overhead.
 - `MAX_FUEL` adds per-instruction metering. Leave it at `0` (off) unless you need deterministic CPU budgets — metering has measurable overhead and is compile-affecting.
 - `MAX_MEMORY_BYTES` caps guest memory growth; `POOL_MAX_MEMORY_BYTES` must be at least the largest guest's requirement or instantiation falls back off the pool.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -17,7 +17,7 @@ Omnia is configured entirely through environment variables (runtime options and 
 
 | Variable             | Default               | Meaning                                                               |
 | -------------------- | --------------------- | --------------------------------------------------------------------- |
-| `GUEST_TIMEOUT_MS`   | `30000`               | Wall-clock cap on a single guest invocation.                          |
+| `GUEST_TIMEOUT_MS`   | `30000`               | Wall-clock cap on a single server/dispatch guest invocation. Command mode (`wasi:cli/run`) is uncapped. |
 | `MAX_MEMORY_BYTES`   | `268435456` (256 MiB) | Maximum linear memory a guest may grow to.                            |
 | `MAX_FUEL`           | `0` (off)             | Per-invocation fuel budget; `0` disables metering. Compile-affecting. |
 | `MAX_DISPATCH_DEPTH` | `8`                   | Maximum nesting depth for host-mediated guest-to-guest calls.         |

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -47,7 +47,7 @@ Sandboxing without resource limits is denial-of-service waiting to happen. Each 
 
 | Limit | Variable | Default |
 | ----- | -------- | ------- |
-| Wall-clock time | `GUEST_TIMEOUT_MS` | 30 s |
+| Wall-clock time | `GUEST_TIMEOUT_MS` | 30 s (server/dispatch; command mode uncapped) |
 | Linear memory | `MAX_MEMORY_BYTES` | 256 MiB |
 | Instruction budget | `MAX_FUEL` | off (`0`) |
 | Preemption granularity | `EPOCH_TICK_MS` | 10 ms |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -76,7 +76,7 @@ Manifest-relative resolution: `source.path` and `[[mount]] path` in a manifest *
 
 ### The guest times out (`epoch deadline` / invocation aborted around 30s)
 
-`GUEST_TIMEOUT_MS` (default 30000) caps each invocation. Raise it for legitimately long work — model completions through slow backends are the common case.
+`GUEST_TIMEOUT_MS` (default 30000) caps each **server** or link-dispatch invocation. Raise it for legitimately long request work. Command mode (`wasi:cli/run`) has no wall-clock cap — if a CLI guest appears to time out, check a backend timeout (for example `CURSOR_TIMEOUT_SECS`) or an external process deadline.
 
 ### The guest traps growing memory
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Removing the command-mode timeout increases exposure to hung or infinitely looping CLI guests holding process resources until killed externally; server/dispatch paths remain capped.
> 
> **Overview**
> **Command mode (`wasi:cli/run`) no longer applies the `GUEST_TIMEOUT_MS` wall-clock limit** — long-running CLI jobs, agents, and batch tasks can run past the default 30s cap that still applies to server triggers and link dispatch.
> 
> The change is in `run_guest` in `command.rs`: the `tokio::time::timeout` wrapper around `wasi:cli/run` was removed so the guest run completes without a host-enforced deadline. Docs and `RuntimeOptions` comments now state that **`GUEST_TIMEOUT_MS` bounds server/dispatch invocations only**; troubleshooting notes that apparent CLI timeouts likely come from backend or external deadlines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b30fa1e401e609c8d9b9735a93ce16ae65f47311. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->