### PR TITLE
No timeout for CLI

### DIFF
--- a/crates/omnia/src/deployment.rs
+++ b/crates/omnia/src/deployment.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeSet;
 use std::env;
 use std::marker::PhantomData;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 pub use manifest::{
@@ -67,6 +68,7 @@ pub struct DeploymentBuilder<P = WasmOnly> {
     command_guest: Option<GuestId>,
     program_name: Option<String>,
     log_mode: Option<LogMode>,
+    guest_timeout: Option<Duration>,
     policy: PhantomData<fn() -> P>,
 }
 
@@ -84,6 +86,7 @@ impl<P> std::fmt::Debug for DeploymentBuilder<P> {
             .field("command_guest", &self.command_guest)
             .field("program_name", &self.program_name)
             .field("log_mode", &self.log_mode)
+            .field("guest_timeout", &self.guest_timeout)
             .finish_non_exhaustive()
     }
 }
@@ -101,6 +104,7 @@ impl Default for DeploymentBuilder<WasmOnly> {
             command_guest: None,
             program_name: None,
             log_mode: None,
+            guest_timeout: None,
             policy: PhantomData,
         }
     }
@@ -219,6 +223,14 @@ impl<P> DeploymentBuilder<P> {
         self
     }
 
+    /// Override the wall-clock cap on server and server-rooted link-dispatch
+    /// invocations for this deployment. Unset defers to `GUEST_TIMEOUT_MS`.
+    #[must_use]
+    pub const fn guest_timeout(mut self, timeout: Duration) -> Self {
+        self.guest_timeout = Some(timeout);
+        self
+    }
+
     /// Resolve the manifest and build the deployment under `policy`.
     async fn build_inner<T: WasiView + 'static>(
         self, policy: ArtifactPolicy,
@@ -262,6 +274,9 @@ impl<P> DeploymentBuilder<P> {
         deployment.http_paths = self.http_paths;
         deployment.http_listener = self.http_listener;
         deployment.command_guest = self.command_guest;
+        if let Some(timeout) = self.guest_timeout {
+            deployment.options.guest_timeout = timeout;
+        }
         Ok(deployment)
     }
 }
@@ -290,6 +305,7 @@ impl DeploymentBuilder<WasmOnly> {
             command_guest: self.command_guest,
             program_name: self.program_name,
             log_mode: self.log_mode,
+            guest_timeout: self.guest_timeout,
             policy: PhantomData,
         }
     }

--- a/crates/omnia/src/dispatch.rs
+++ b/crates/omnia/src/dispatch.rs
@@ -30,7 +30,7 @@ mod serve;
 mod transport;
 mod value;
 
-pub use handle::DispatchHandle;
+pub use handle::{DispatchHandle, as_command_chain};
 pub use host::Dispatcher;
 // `polyfill_late`, `serve_guest`, `Endpoint`, and `ResolveHook` are
 // crate-internal: this module is private, and `lib.rs` does not re-export them.

--- a/crates/omnia/src/dispatch/handle.rs
+++ b/crates/omnia/src/dispatch/handle.rs
@@ -12,26 +12,50 @@ use super::transport::InProcess;
 use crate::registry::GuestId;
 
 tokio::task_local! {
-    // The nesting depth of the dispatch chain the current task is serving
-    // (0 at a chain root). Carried across the in-process carrier via the
-    // wRPC accept context and re-established around each served invocation,
-    // so concurrent, unrelated chains never share a depth budget.
-    static CHAIN_DEPTH: usize;
+    // The context of the dispatch chain the current task is serving. Carried
+    // across the in-process carrier via the wRPC accept context and
+    // re-established around each served invocation, so concurrent, unrelated
+    // chains never share a depth budget or a wall-clock policy.
+    static CHAIN_CTX: ChainCtx;
 }
 
-/// Run `fut` with the chain depth carried over from an incoming dispatch, so
+/// Per-chain dispatch context: the nesting depth (0 at a chain root) plus
+/// whether the chain root runs uncapped (a command-mode `wasi:cli/run` drive).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ChainCtx {
+    pub(super) depth: usize,
+    pub(super) uncapped: bool,
+}
+
+/// Run `fut` with the chain context carried over from an incoming dispatch, so
 /// nested host-mediated calls made while serving it count against the same
-/// chain.
-pub(super) fn with_depth<F>(depth: usize, fut: F) -> impl Future<Output = F::Output>
+/// chain and inherit its wall-clock policy.
+pub(super) fn with_chain<F>(ctx: ChainCtx, fut: F) -> impl Future<Output = F::Output>
 where
     F: Future,
 {
-    CHAIN_DEPTH.scope(depth, fut)
+    CHAIN_CTX.scope(ctx, fut)
 }
 
-/// The chain depth of the dispatch currently being served (0 at a chain root).
-fn current_depth() -> usize {
-    CHAIN_DEPTH.try_with(|depth| *depth).unwrap_or(0)
+/// Run `fut` as a command-mode chain root: link dispatches it makes (and their
+/// nested hops) run without the `GUEST_TIMEOUT_MS` wall-clock cap.
+pub fn as_command_chain<F>(fut: F) -> impl Future<Output = F::Output>
+where
+    F: Future,
+{
+    CHAIN_CTX.scope(
+        ChainCtx {
+            depth: 0,
+            uncapped: true,
+        },
+        fut,
+    )
+}
+
+/// The context of the dispatch chain currently being served (a capped root
+/// outside any scope).
+fn current_chain() -> ChainCtx {
+    CHAIN_CTX.try_with(|ctx| *ctx).unwrap_or_default()
 }
 
 /// The long-lived dispatch state shared by every polyfilled import.
@@ -124,13 +148,15 @@ impl DispatchHandle {
     }
 
     /// Enter a dispatch, bounding the current chain's nesting depth; returns
-    /// the depth the dispatched call runs at, to be carried to the serve side.
+    /// the context the dispatched call runs at (depth plus the inherited
+    /// wall-clock policy), to be carried to the serve side.
     ///
     /// Depth is per call chain (A->B->C, each awaited to completion before the
     /// caller returns), so concurrent, unrelated chains never contend for the
     /// same budget.
-    pub(super) fn enter(&self, target: &GuestId) -> Result<usize> {
-        let depth = current_depth() + 1;
+    pub(super) fn enter(&self, target: &GuestId) -> Result<ChainCtx> {
+        let current = current_chain();
+        let depth = current.depth + 1;
         if depth > self.max_depth {
             bail!(
                 "link dispatch depth {depth} exceeds maximum {} (target `{target}`); raise \
@@ -138,7 +164,10 @@ impl DispatchHandle {
                 self.max_depth
             );
         }
-        Ok(depth)
+        Ok(ChainCtx {
+            depth,
+            uncapped: current.uncapped,
+        })
     }
 }
 
@@ -146,7 +175,7 @@ impl DispatchHandle {
 mod tests {
     use std::sync::Arc;
 
-    use super::{CHAIN_DEPTH, DispatchHandle};
+    use super::{CHAIN_CTX, ChainCtx, DispatchHandle};
     use crate::dispatch::FirstArgSelector;
     use crate::registry::GuestId;
 
@@ -159,18 +188,50 @@ mod tests {
         )
     }
 
+    const fn at_depth(depth: usize) -> ChainCtx {
+        ChainCtx {
+            depth,
+            uncapped: false,
+        }
+    }
+
     #[test]
     fn depth_bound() {
         let handle = handle(2);
         let target = GuestId::from("t");
 
         // A chain root enters at depth 1; a serve at depth 1 enters at 2.
-        assert_eq!(handle.enter(&target).expect("root within bound"), 1);
-        CHAIN_DEPTH.sync_scope(1, || {
-            assert_eq!(handle.enter(&target).expect("depth 2 within bound"), 2);
+        assert_eq!(handle.enter(&target).expect("root within bound").depth, 1);
+        CHAIN_CTX.sync_scope(at_depth(1), || {
+            assert_eq!(handle.enter(&target).expect("depth 2 within bound").depth, 2);
         });
-        CHAIN_DEPTH.sync_scope(2, || {
+        CHAIN_CTX.sync_scope(at_depth(2), || {
             handle.enter(&target).expect_err("depth 3 exceeds the maximum");
+        });
+    }
+
+    #[test]
+    fn uncapped_inherited_from_chain_root() {
+        let handle = handle(8);
+        let target = GuestId::from("t");
+
+        // Outside any scope (a server-rooted chain) dispatches stay capped.
+        assert!(!handle.enter(&target).expect("capped root").uncapped);
+
+        // A command-mode root marks the chain; nested hops inherit the bit.
+        let ctx = ChainCtx {
+            depth: 0,
+            uncapped: true,
+        };
+        CHAIN_CTX.sync_scope(ctx, || {
+            let entered = handle.enter(&target).expect("uncapped root");
+            assert!(entered.uncapped, "the first hop inherits uncapped");
+            CHAIN_CTX.sync_scope(entered, || {
+                assert!(
+                    handle.enter(&target).expect("nested hop").uncapped,
+                    "nested hops inherit uncapped"
+                );
+            });
         });
     }
 }

--- a/crates/omnia/src/dispatch/link.rs
+++ b/crates/omnia/src/dispatch/link.rs
@@ -196,6 +196,9 @@ struct Call<'a> {
     param_types: Vec<Type>,
     result_types: Vec<Type>,
     client: super::transport::LinkClient,
+    // Whether this call's chain root runs uncapped (command mode): the
+    // round-trip then skips the `guest_timeout` wall-clock bound.
+    uncapped: bool,
 }
 
 /// Shared per-call preamble: select the target, reject crossing resources,
@@ -223,7 +226,7 @@ async fn prepare<'a>(
 
     ensure_endpoint(handle, &target, interface).await?;
 
-    let depth = handle.enter(&target)?;
+    let ctx = handle.enter(&target)?;
 
     let param_types: Vec<Type> = ty.params().map(|(_, ty)| ty).collect();
     let result_types: Vec<Type> = ty.results().collect();
@@ -234,7 +237,7 @@ async fn prepare<'a>(
         param_types.len()
     );
 
-    let client = handle.transport().connect(&target, depth)?;
+    let client = handle.transport().connect(&target, ctx)?;
 
     Ok(Call {
         start,
@@ -243,6 +246,7 @@ async fn prepare<'a>(
         param_types,
         result_types,
         client,
+        uncapped: ctx.uncapped,
     })
 }
 
@@ -274,6 +278,22 @@ fn timeout_error(
     )
 }
 
+/// Await the dispatch round-trip, bounded by `guest_timeout` unless the call's
+/// chain root runs uncapped (a command-mode `wasi:cli/run` drive).
+async fn bounded<F>(
+    handle: &DispatchHandle, call: &Call<'_>, interface: &str, func: &str, fut: F,
+) -> Result<()>
+where
+    F: Future<Output = Result<()>>,
+{
+    if call.uncapped {
+        return fut.await;
+    }
+    tokio::time::timeout(handle.timeout(), fut)
+        .await
+        .map_err(|_elapsed| timeout_error(handle, &call.target, interface, func))?
+}
+
 fn log_dispatch(call: &Call<'_>, interface: &str, func: &str) {
     let elapsed_us = u64::try_from(call.start.elapsed().as_micros()).unwrap_or(u64::MAX);
     tracing::debug!(
@@ -302,10 +322,11 @@ where
 
     // Invoke over the carrier; the request is written and flushed here, the
     // results stream back on `incoming`. No deferred (async) parameters, so the
-    // outgoing half carries nothing further and is dropped. The round-trip is
-    // bounded by `guest_timeout` so a hung target cannot stall the caller.
+    // outgoing half carries nothing further and is dropped. On a server-rooted
+    // chain the round-trip is bounded by `guest_timeout` so a hung target
+    // cannot stall the caller; a command-rooted chain runs uncapped.
     let target = &call.target;
-    tokio::time::timeout(handle.timeout(), async {
+    let round_trip = async {
         let (_outgoing, incoming) =
             call.client.invoke((), interface, func, buf.freeze(), &[[]; 0]).await.with_context(
                 || format!("invoking link target `{target}` for `{interface}/{func}`"),
@@ -319,9 +340,8 @@ where
                 .with_context(|| format!("decoding result {index} from `{target}`"))?;
         }
         anyhow::Ok(())
-    })
-    .await
-    .map_err(|_elapsed| timeout_error(handle, &call.target, interface, func))??;
+    };
+    bounded(handle, &call, interface, func, round_trip).await?;
 
     log_dispatch(&call, interface, func);
     Ok(())
@@ -347,7 +367,7 @@ where
 
     // Invoke over the carrier; see `send` for the streaming/timeout contract.
     let target = &call.target;
-    tokio::time::timeout(handle.timeout(), async {
+    let round_trip = async {
         let (_outgoing, incoming) =
             call.client.invoke((), interface, func, buf.freeze(), &[[]; 0]).await.with_context(
                 || format!("invoking link target `{target}` for `{interface}/{func}`"),
@@ -360,9 +380,8 @@ where
                 .with_context(|| format!("decoding result {index} from `{target}`"))?;
         }
         anyhow::Ok(())
-    })
-    .await
-    .map_err(|_elapsed| timeout_error(handle, &call.target, interface, func))??;
+    };
+    bounded(handle, &call, interface, func, round_trip).await?;
 
     log_dispatch(&call, interface, func);
     Ok(())

--- a/crates/omnia/src/dispatch/serve.rs
+++ b/crates/omnia/src/dispatch/serve.rs
@@ -9,7 +9,7 @@ use futures::StreamExt as _;
 use wasmtime::component::types;
 use wrpc_wasmtime::ServeExt as _;
 
-use super::handle::with_depth;
+use super::handle::with_chain;
 use super::transport::{Endpoint, InProcServer};
 use crate::registry::{Guest, GuestId};
 use crate::runtime::Runtime;
@@ -121,11 +121,12 @@ where
                 let mut stream = pin!(stream);
                 while let Some(invocation) = stream.next().await {
                     match invocation {
-                        Ok((depth, fut)) => {
-                            // Re-establish the caller's chain depth around the
-                            // served invocation so nested dispatches it makes
-                            // stay bounded per chain.
-                            tokio::spawn(with_depth(depth, async move {
+                        Ok((ctx, fut)) => {
+                            // Re-establish the caller's chain context around
+                            // the served invocation so nested dispatches it
+                            // makes stay bounded per chain and inherit the
+                            // chain's wall-clock policy.
+                            tokio::spawn(with_chain(ctx, async move {
                                 if let Err(error) = fut.await {
                                     tracing::error!(%error, "link serve invocation failed");
                                 }

--- a/crates/omnia/src/dispatch/transport.rs
+++ b/crates/omnia/src/dispatch/transport.rs
@@ -26,6 +26,7 @@ use wasmtime::component::ResourceTable;
 use wrpc_transport::frame::{Oneshot, Server};
 use wrpc_wasmtime::{SharedResourceTable, WrpcCtx, WrpcCtxView};
 
+use super::handle::ChainCtx;
 use crate::registry::GuestId;
 
 /// Default in-process pipe buffer size (64 kibibytes).
@@ -33,8 +34,9 @@ const DUPLEX_BUF: usize = 1 << 16;
 
 /// The in-process wRPC server type: framed transport over a `tokio::io::duplex`
 /// byte stream, one connection accepted per dispatched call. The accept
-/// context carries the caller's chain depth to the serve side.
-pub type InProcServer = Server<usize, ReadHalf<DuplexStream>, WriteHalf<DuplexStream>>;
+/// context carries the caller's chain context (depth plus wall-clock policy)
+/// to the serve side.
+pub type InProcServer = Server<ChainCtx, ReadHalf<DuplexStream>, WriteHalf<DuplexStream>>;
 
 /// The in-process wRPC client handle: a single stream pair to one target's
 /// server, used for exactly one invocation.
@@ -57,13 +59,14 @@ pub trait LinkTransport: Send + Sync + 'static {
     type Client: wrpc_transport::Invoke<Context = ()>;
 
     /// Open a fresh client connection to `target` for a single invocation
-    /// running at `depth` in its dispatch chain; the transport carries the
-    /// depth to the serve side so nested calls stay bounded.
+    /// running at `ctx` in its dispatch chain; the transport carries the
+    /// context to the serve side so nested calls stay bounded and inherit the
+    /// chain's wall-clock policy.
     ///
     /// # Errors
     ///
     /// Returns an error if `target` has no bound endpoint on this transport.
-    fn connect(&self, target: &GuestId, depth: usize) -> Result<Self::Client>;
+    fn connect(&self, target: &GuestId, ctx: ChainCtx) -> Result<Self::Client>;
 }
 
 /// A guest's serve side: its wRPC server plus the detached tasks draining each
@@ -220,7 +223,7 @@ impl WrpcCtx<InProcClient> for WrpcState {
 impl LinkTransport for InProcess {
     type Client = InProcClient;
 
-    fn connect(&self, target: &GuestId, depth: usize) -> Result<Self::Client> {
+    fn connect(&self, target: &GuestId, ctx: ChainCtx) -> Result<Self::Client> {
         let server = self.server(target).with_context(|| {
             format!(
                 "no in-process endpoint serves guest `{target}` (is it registered and does it \
@@ -234,7 +237,7 @@ impl LinkTransport for InProcess {
         let (client, server_stream) = Oneshot::duplex(DUPLEX_BUF);
         let (server_rx, server_tx) = split(server_stream);
         tokio::spawn(async move {
-            if let Err(error) = server.accept(depth, server_tx, server_rx).await {
+            if let Err(error) = server.accept(ctx, server_tx, server_rx).await {
                 tracing::error!(%error, "in-process link accept failed");
             }
         });

--- a/crates/omnia/src/lib.rs
+++ b/crates/omnia/src/lib.rs
@@ -29,7 +29,7 @@ pub use self::deployment::{
 };
 pub use self::dispatch::{
     Dispatcher, EnsureError, FirstArgSelector, GuestResolver, GuestSelector, HttpPaths, LinkClient,
-    WrpcState, serve_links,
+    WrpcState, as_command_chain, serve_links,
 };
 pub use self::host::{
     Backend, FromEnv, FutureResult, HasTable, Host, NoOptions, Proxy, Server, get_cloned,

--- a/crates/omnia/src/options.rs
+++ b/crates/omnia/src/options.rs
@@ -48,7 +48,7 @@ use wasmtime::{Config, Enabled, InstanceAllocationStrategy, PoolingAllocationCon
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, FromEnv)]
 pub struct RuntimeOptions {
-    /// Wall-clock cap on a server or link-dispatch invocation (`GUEST_TIMEOUT_MS`, default 30s, min 1ms; command mode uncapped).
+    /// Wall-clock cap on a server or server-rooted link-dispatch invocation (`GUEST_TIMEOUT_MS`, default 30s, min 1ms; a command-mode chain, including its link hops, is uncapped).
     #[env(from = "GUEST_TIMEOUT_MS", default = "30000", with = parse_timeout)]
     pub guest_timeout: Duration,
     /// Epoch-increment interval, also the CPU-bound guest yield granularity (`EPOCH_TICK_MS`, default 10ms, min 1ms).

--- a/crates/omnia/src/runtime/command.rs
+++ b/crates/omnia/src/runtime/command.rs
@@ -70,8 +70,13 @@ where
     let instance = runtime.instantiate(guest.instance_pre(), &mut store).await?;
     let command = Command::new(&mut store, &instance)?;
 
-    let outcome =
-        store.run_concurrent(async move |store| command.wasi_cli_run().call_run(store).await).await;
+    // A command chain root: link dispatches the guest makes (and their nested
+    // hops) run without the `GUEST_TIMEOUT_MS` wall-clock cap, matching the
+    // uncapped `wasi:cli/run` drive itself.
+    let outcome = crate::dispatch::as_command_chain(
+        store.run_concurrent(async move |store| command.wasi_cli_run().call_run(store).await),
+    )
+    .await;
 
     let status = match outcome {
         Ok(Ok(Ok(()))) => ExitStatus::SUCCESS,

--- a/crates/seam-suite/tests/seam/guest_link.rs
+++ b/crates/seam-suite/tests/seam/guest_link.rs
@@ -20,7 +20,7 @@ use futures::FutureExt as _;
 use omnia::wasmtime::component::Val;
 use omnia::{
     DeploymentBuilder, FutureResult, GuestArtifact, GuestEntry, GuestId, GuestResolver, Manifest,
-    MountRegistry, Runtime, serve_links,
+    MountRegistry, Runtime, as_command_chain, serve_links,
 };
 use omnia_testkit::{find_guest, precompiled_artifact as precompiled, raw_wasm};
 use tokio::sync::Notify;
@@ -104,12 +104,23 @@ async fn call_router_to_slow(
 /// Build the two-guest deployment and wire the serve side, returning the
 /// runtime plus the shared bundle-clone counter.
 async fn build_runtime() -> Result<(Runtime<Counter>, Arc<AtomicUsize>)> {
-    build_runtime_with(None).await
+    build_runtime_inner(None, None).await
 }
 
 /// [`build_runtime`] with an optional resolve-on-miss resolver installed.
 async fn build_runtime_with(
     resolver: Option<Arc<dyn GuestResolver>>,
+) -> Result<(Runtime<Counter>, Arc<AtomicUsize>)> {
+    build_runtime_inner(resolver, None).await
+}
+
+/// [`build_runtime`] with a programmatic `guest_timeout` cap.
+async fn build_runtime_capped(timeout: Duration) -> Result<(Runtime<Counter>, Arc<AtomicUsize>)> {
+    build_runtime_inner(None, Some(timeout)).await
+}
+
+async fn build_runtime_inner(
+    resolver: Option<Arc<dyn GuestResolver>>, guest_timeout: Option<Duration>,
 ) -> Result<(Runtime<Counter>, Arc<AtomicUsize>)> {
     let responder = find_guest("guest_link_responder_wasm.wasm");
     let router = find_guest("guest_link_router_wasm.wasm");
@@ -118,7 +129,10 @@ async fn build_runtime_with(
         .guest(GuestEntry::new("responder", responder))
         .guest(GuestEntry::new("router", router).link("omnia:link/echo"));
 
-    let builder = DeploymentBuilder::new().manifest(manifest).precompiled();
+    let mut builder = DeploymentBuilder::new().manifest(manifest).precompiled();
+    if let Some(timeout) = guest_timeout {
+        builder = builder.guest_timeout(timeout);
+    }
     // SAFETY: `find_guest` only returns artifacts this workspace built and
     // serialized itself (`cargo make test-guests`).
     let deployment = unsafe { builder.build::<TestCtx>() }.await.context("building runtime")?;
@@ -253,6 +267,40 @@ fn dispatch_async() -> Result<()> {
             let echoed = call_router(&runtime, "run-slow", message).await?;
             assert_eq!(echoed, format!("responder echoes slowly: {message}"));
         }
+
+        Ok(())
+    })
+}
+
+// A server-rooted chain bounds each link-dispatch hop by `guest_timeout`: a
+// cap shorter than the responder's `echo-slow` park (5ms) times the hop out.
+#[test]
+fn dispatch_timeout_on_server_chain() -> Result<()> {
+    fixture::RT.block_on(async {
+        let (runtime, _clones) = build_runtime_capped(Duration::from_millis(1)).await?;
+
+        let error = call_router(&runtime, "run-slow", "hello")
+            .await
+            .expect_err("a 1ms cap must time out the parked responder");
+        ensure!(
+            format!("{error:#}").contains("timed out after"),
+            "the failure is the link-dispatch timeout, got: {error:#}"
+        );
+
+        Ok(())
+    })
+}
+
+// The same short cap under a command-mode chain root does not apply: link
+// hops on a command chain run uncapped, matching the uncapped `wasi:cli/run`
+// drive itself.
+#[test]
+fn dispatch_uncapped_on_command_chain() -> Result<()> {
+    fixture::RT.block_on(async {
+        let (runtime, _clones) = build_runtime_capped(Duration::from_millis(1)).await?;
+
+        let echoed = as_command_chain(call_router(&runtime, "run-slow", "hello")).await?;
+        assert_eq!(echoed, "responder echoes slowly: hello");
 
         Ok(())
     })

--- a/docs/guides/composing-a-runtime.md
+++ b/docs/guides/composing-a-runtime.md
@@ -42,7 +42,7 @@ cargo run -- run ./path/to/guest.wasm
 The optional `mode` key selects how the runtime drives guests:
 
 - **`mode: server`** (the default) — the runtime stays up and serves requests. Trigger hosts (`WasiHttp`, `WasiMessaging`, `WasiWebSocket`) listen for traffic and instantiate a fresh guest instance per request.
-- **`mode: command`** — the runtime drives the guest's `wasi:cli/run` export exactly once, then exits with the guest's status. Use this for jobs, CLIs, and agent tasks. Unlike server triggers, command mode applies no `GUEST_TIMEOUT_MS` wall-clock cap.
+- **`mode: command`** — the runtime drives the guest's `wasi:cli/run` export exactly once, then exits with the guest's status. Use this for jobs, CLIs, and agent tasks. Unlike server triggers, command mode applies no `GUEST_TIMEOUT_MS` wall-clock cap — to the run itself or to any link dispatch made along its call chain.
 
 ```rust
 omnia::runtime!({

--- a/docs/guides/performance-tuning.md
+++ b/docs/guides/performance-tuning.md
@@ -53,7 +53,7 @@ Per-request tuning doesn't help cold starts. For those, pre-compile guests (`com
 
 ## Limits that interact with latency
 
-- `GUEST_TIMEOUT_MS` (default 30s) bounds each server/dispatch invocation wall-clock (command mode is uncapped); `EPOCH_TICK_MS` (default 10ms) is the granularity at which CPU-bound guests yield and timeouts are enforced. Lowering the tick tightens timeout precision at slight overhead.
+- `GUEST_TIMEOUT_MS` (default 30s) bounds each server invocation and each server-rooted link-dispatch hop wall-clock (a command-mode chain, including its link hops, is uncapped); `EPOCH_TICK_MS` (default 10ms) is the granularity at which CPU-bound guests yield and timeouts are enforced. Lowering the tick tightens timeout precision at slight overhead.
 - `MAX_FUEL` adds per-instruction metering. Leave it at `0` (off) unless you need deterministic CPU budgets — metering has measurable overhead and is compile-affecting.
 - `MAX_MEMORY_BYTES` caps guest memory growth; `POOL_MAX_MEMORY_BYTES` must be at least the largest guest's requirement or instantiation falls back off the pool.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -30,7 +30,7 @@ A binary built with the `runtime!` macro's `program:` key reserves two host flag
 
 | Variable             | Default               | Meaning                                                               |
 | -------------------- | --------------------- | --------------------------------------------------------------------- |
-| `GUEST_TIMEOUT_MS`   | `30000`               | Wall-clock cap on a single server/dispatch guest invocation. Command mode (`wasi:cli/run`) is uncapped. |
+| `GUEST_TIMEOUT_MS`   | `30000`               | Wall-clock cap on a single server guest invocation and each link-dispatch hop on a server-rooted chain. A command-mode (`wasi:cli/run`) chain is uncapped, including its link hops. |
 | `MAX_MEMORY_BYTES`   | `268435456` (256 MiB) | Maximum linear memory a guest may grow to.                            |
 | `MAX_FUEL`           | `0` (off)             | Per-invocation fuel budget; `0` disables metering. Compile-affecting. |
 | `MAX_DISPATCH_DEPTH` | `8`                   | Maximum nesting depth for host-mediated guest-to-guest calls.         |

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -47,7 +47,7 @@ Sandboxing without resource limits is denial-of-service waiting to happen. Each 
 
 | Limit | Variable | Default |
 | ----- | -------- | ------- |
-| Wall-clock time | `GUEST_TIMEOUT_MS` | 30 s (server/dispatch; command mode uncapped) |
+| Wall-clock time | `GUEST_TIMEOUT_MS` | 30 s (server invocations and server-rooted link hops; a command-mode chain, link hops included, is uncapped) |
 | Linear memory | `MAX_MEMORY_BYTES` | 256 MiB |
 | Instruction budget | `MAX_FUEL` | off (`0`) |
 | Preemption granularity | `EPOCH_TICK_MS` | 10 ms |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -76,7 +76,7 @@ Manifest-relative resolution: `source.path` and `[[mount]] path` in a manifest *
 
 ### The guest times out (`epoch deadline` / invocation aborted around 30s)
 
-`GUEST_TIMEOUT_MS` (default 30000) caps each **server** or link-dispatch invocation. Raise it for legitimately long request work. Command mode (`wasi:cli/run`) has no wall-clock cap — if a CLI guest appears to time out, check a backend timeout (for example `CURSOR_TIMEOUT_SECS`) or an external process deadline.
+`GUEST_TIMEOUT_MS` (default 30000) caps each **server** invocation and each link-dispatch hop on a server-rooted chain. Raise it for legitimately long request work. A command-mode (`wasi:cli/run`) chain has no wall-clock cap — neither the run itself nor the link dispatches it makes — so if a CLI guest appears to time out, check a backend timeout (for example `CURSOR_TIMEOUT_SECS`) or an external process deadline.
 
 ### The guest traps growing memory
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes wall-clock timeout behavior for command-mode link dispatch (intentional fix); server paths unchanged. Touches dispatch core and resource limits, not auth or data handling.
> 
> **Overview**
> **Command-mode** runs were already uncapped for `wasi:cli/run`, but **host-mediated link hops** on that same chain still hit `GUEST_TIMEOUT_MS` — this PR aligns link dispatch with the run.
> 
> Dispatch chain context now carries an **`uncapped`** flag (alongside depth) via task-local `ChainCtx`, propagated through in-process wRPC accept/serve. **`as_command_chain`** marks a chain root as uncapped; **`wasi:cli/run`** uses it, and nested link dispatches inherit the policy. Server-rooted chains stay capped; link round-trips use a shared **`bounded`** helper that skips the wall-clock timeout when uncapped.
> 
> **`DeploymentBuilder::guest_timeout`** overrides the deployment cap for tests/embedders. Docs and seam tests cover capped server chains vs uncapped command chains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b015b5fd3856ef7ae4c2c6f70f8bfafdc11b7db. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->