### PR TITLE
Add feature flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,29 +107,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "pkg-config",
-]
-
-[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,8 +317,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -428,15 +403,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "cobs"
@@ -887,12 +853,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,12 +1058,6 @@ dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1722,16 +1676,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
-dependencies = [
- "getrandom 0.4.3",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2304,6 +2248,7 @@ dependencies = [
  "omnia",
  "omnia-wasi-keyvalue",
  "reqwest 0.13.4",
+ "rustls",
  "serde",
  "serde_json",
  "tokio",
@@ -2481,19 +2426,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-http"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
-dependencies = [
- "async-trait",
- "bytes",
- "http",
- "opentelemetry",
- "reqwest 0.13.4",
-]
-
-[[package]]
 name = "opentelemetry-otlp"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2501,11 +2433,9 @@ checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
- "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.13.4",
  "thiserror 2.0.19",
  "tokio",
  "tonic",
@@ -2780,7 +2710,6 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
@@ -3082,8 +3011,6 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -3095,10 +3022,8 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -3205,7 +3130,6 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -3270,7 +3194,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -20,7 +20,7 @@ skip_rust_env_info = true
 dependencies = ["audit", "fmt", "lint", "outdated", "deps"]
 
 [tasks.ci]
-dependencies = ["fmt", "lint", "test", "test-seam", "test-docs", "docs", "vet", "outdated", "deny"]
+dependencies = ["fmt", "lint", "features", "test", "seam", "test-docs", "docs", "vet", "outdated", "deny"]
 
 # -------------------------------------
 # Individual Actions
@@ -50,6 +50,17 @@ cargo +nightly udeps --all-targets
 install_crate = "cargo-udeps"
 # args = ["machete", "--skip-target-dir"]
 # install_crate = "cargo-machete"
+
+# Feature gates: the flagged crates must stay warning-free without their
+# default features so the gates don't rot (`lint` only covers --all-features).
+[tasks.features]
+script = '''
+cargo clippy -p omnia -p omnia-wasi-sql -p omnia-wasi-identity -p omnia-guest --no-default-features --all-targets -- -D warnings
+cargo clippy -p omnia --no-default-features --features cli --all-targets -- -D warnings
+cargo clippy -p omnia --no-default-features --features jit --all-targets -- -D warnings
+cargo clippy -p omnia --no-default-features --features otlp --all-targets -- -D warnings
+'''
+install_crate = { rustup_component_name = "clippy" }
 
 # Fmt (fix in place)
 [tasks.fmt]
@@ -90,7 +101,7 @@ env = { RUSTFLAGS = "-Dwarnings" }
 # Seam tier: the consolidated guest–host suite, one process so the runtime
 # fixtures (component, linker, InstancePre) are built once.
 # `test-guests` lives in examples/Makefile.toml (extended above).
-[tasks.test-seam]
+[tasks.seam]
 dependencies = ["test-guests"]
 command = "cargo"
 args = ["test", "-p", "omnia-seam-suite", "--test", "seam"]

--- a/crates/omnia-guest/Cargo.toml
+++ b/crates/omnia-guest/Cargo.toml
@@ -13,21 +13,31 @@ categories.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = ["cli", "orm"]
+
+# Enables the typed command router (`api::command::Router`), built on `clap`.
+cli = ["dep:clap", "dep:clap_complete"]
+
+# Enables the SQL ORM (`orm`), the table/document capabilities, and the
+# document-store re-exports.
+orm = ["dep:omnia-wasi-docstore", "dep:omnia-wasi-sql", "dep:sea-query"]
+
 [dependencies]
 anyhow.workspace = true
 axum = { workspace = true, features = ["json", "macros", "query"] }
 bon.workspace = true
 bytes.workspace = true
 chrono.workspace = true
-clap.workspace = true
-clap_complete.workspace = true
+clap = { workspace = true, optional = true }
+clap_complete = { workspace = true, optional = true }
 http.workspace = true
 http-body.workspace = true
-omnia-wasi-sql.workspace = true
+omnia-wasi-sql = { workspace = true, optional = true }
 omnia-wasi-http.workspace = true
-omnia-wasi-docstore.workspace = true
+omnia-wasi-docstore = { workspace = true, optional = true }
 rand.workspace = true
-sea-query.workspace = true
+sea-query = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 serde_urlencoded.workspace = true

--- a/crates/omnia-guest/README.md
+++ b/crates/omnia-guest/README.md
@@ -126,6 +126,13 @@ fn validate(name: &str) -> Result<(), omnia_guest::Error> {
 
 See the [workspace documentation](https://github.com/augentic/omnia) for the full architecture guide.
 
+## Cargo features
+
+- `cli` *(default)*: the typed command router (`api::command::Router`), built on `clap`.
+- `orm` *(default)*: the SQL ORM, table/document capabilities, and document-store re-exports.
+
+Guests that serve only HTTP or messaging can disable defaults to shrink wasm build time and size.
+
 ## License
 
 MIT OR Apache-2.0

--- a/crates/omnia-guest/src/api/command.rs
+++ b/crates/omnia-guest/src/api/command.rs
@@ -2,12 +2,14 @@
 
 mod builder;
 mod response;
+#[cfg(feature = "cli")]
 mod router;
 
 pub use builder::{Binding, Decoder, Outcome, Projector, Run, TryIntoDecoder, run};
 pub use response::CommandResponse;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "cli"))]
 pub use router::execute_wasi;
+#[cfg(feature = "cli")]
 pub use router::{
     BuildError, Completions, Namespace, NoGlobals, RouteInfo, Router, RouterBuilder, Selector,
 };

--- a/crates/omnia-guest/src/api/command/builder.rs
+++ b/crates/omnia-guest/src/api/command/builder.rs
@@ -145,6 +145,8 @@ impl<A, O, D> Run<A, O, D> {
 }
 
 /// A fully typed route ready for router registration.
+// Only the `cli`-gated router reads these fields.
+#[cfg_attr(not(feature = "cli"), allow(dead_code))]
 pub struct Binding<A, O, D, Q> {
     pub(crate) about: Option<&'static str>,
     pub(crate) long_about: Option<&'static str>,

--- a/crates/omnia-guest/src/capabilities.rs
+++ b/crates/omnia-guest/src/capabilities.rs
@@ -7,17 +7,20 @@
 mod blob;
 mod broadcast;
 mod config;
+#[cfg(feature = "orm")]
 mod document;
 mod http;
 mod identity;
 mod messaging;
 pub mod model;
 mod state;
+#[cfg(feature = "orm")]
 mod table;
 
 pub use blob::{BlobStore, ContainerMetadata, ObjectMetadata};
 pub use broadcast::Broadcast;
 pub use config::Config;
+#[cfg(feature = "orm")]
 pub use document::DocumentStore;
 pub use http::HttpRequest;
 pub use identity::Identity;
@@ -27,4 +30,5 @@ pub use model::Model;
 #[cfg(target_arch = "wasm32")]
 pub use model::WasiModel;
 pub use state::StateStore;
+#[cfg(feature = "orm")]
 pub use table::TableStore;

--- a/crates/omnia-guest/src/lib.rs
+++ b/crates/omnia-guest/src/lib.rs
@@ -4,9 +4,11 @@ pub mod api;
 mod capabilities;
 mod error;
 pub mod mcp;
+#[cfg(feature = "orm")]
 pub mod orm;
 
 /// Document store types and helpers (from `omnia-wasi-docstore`).
+#[cfg(feature = "orm")]
 pub mod document_store {
     pub use omnia_wasi_docstore::document_store::*;
 }

--- a/crates/omnia-guest/tests/command.rs
+++ b/crates/omnia-guest/tests/command.rs
@@ -1,5 +1,7 @@
 //! Command router public contract.
 
+#![cfg(feature = "cli")]
+
 use std::any::TypeId;
 use std::error::Error;
 use std::{fmt, io};

--- a/crates/omnia/Cargo.toml
+++ b/crates/omnia/Cargo.toml
@@ -16,10 +16,20 @@ version.workspace = true
 workspace = true
 
 [features]
-default = ["jit"]
+default = ["cli", "jit", "otlp"]
+
+# Enables the standard `omnia run` CLI grammar in generated `main`s and the
+# `clap` re-export. Without it, deployments are direct commands (the macro's
+# `program:` key) or built programmatically via `DeploymentBuilder`.
+cli = ["dep:clap"]
 
 # Enables just-in-time wasm to machine code compilation.
 jit = ["wasmtime/cranelift"]
+
+# Enables the OTLP (gRPC) span and metric exporters. Without it, `Telemetry`
+# still installs the fmt/`EnvFilter` subscriber, while `telemetry::flush` and
+# `telemetry::resource` become no-ops.
+otlp = ["dep:opentelemetry-otlp", "dep:tracing-opentelemetry"]
 
 # Enables memory protection keys (MPK) support in the pooling allocator. MPK
 # only functions on Linux/x86_64; elsewhere it compiles but is inert
@@ -39,18 +49,21 @@ bytes.workspace = true
 cap-fs-ext.workspace = true
 cap-std.workspace = true
 cfg-if.workspace = true
-clap.workspace = true
+clap = { workspace = true, optional = true }
 fromenv.workspace = true
 futures.workspace = true
 http.workspace = true
 opentelemetry.workspace = true
-opentelemetry-otlp = { version = "0.32.0", features = ["grpc-tonic"] }
+# Tonic-only export: the defaults add an HTTP export path (opentelemetry-http →
+# reqwest) that `telemetry.rs` never uses. TLS was never enabled for the gRPC
+# channel (`tls-*` is not a default), so plaintext OTLP behavior is unchanged.
+opentelemetry-otlp = { version = "0.32.0", default-features = false, features = ["grpc-tonic", "metrics", "trace"], optional = true }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
 pastey.workspace = true
 serde.workspace = true
 toml.workspace = true
 tracing.workspace = true
-tracing-opentelemetry.workspace = true
+tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber.workspace = true
 tokio = { workspace = true, features = ["io-util", "macros", "rt", "sync", "time"] }
 tokio-util = { workspace = true, features = ["codec"] }

--- a/crates/omnia/src/lib.rs
+++ b/crates/omnia/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg(not(target_arch = "wasm32"))]
 #![allow(unsafe_code)] // wasmtime component deserialization and deployment hooks
 
+#[cfg(feature = "cli")]
 mod cli;
 mod deployment;
 mod dispatch;
@@ -13,6 +14,7 @@ mod runtime;
 mod store;
 pub mod telemetry;
 
+#[cfg(feature = "cli")]
 pub use clap::Parser;
 pub use omnia_host_macros::runtime;
 #[doc(hidden)]
@@ -22,6 +24,7 @@ pub use wrpc_wasmtime::{WrpcCtxView, WrpcView};
 #[doc(hidden)]
 pub use {anyhow, futures, tokio, wasmtime, wasmtime_wasi};
 
+#[cfg(feature = "cli")]
 pub use self::cli::{Cli, Command};
 pub use self::deployment::{
     Deployment, DeploymentBuilder, GuestArtifact, GuestEntry, HttpRoute, Manifest, Mount,

--- a/crates/omnia/src/runtime.rs
+++ b/crates/omnia/src/runtime.rs
@@ -102,6 +102,7 @@ where
 {
     let plan = match entry::plan(options, env::args_os(), env::var_os("OMNIA_CONFIG")) {
         Ok(plan) => plan,
+        #[cfg(feature = "cli")]
         Err(entry::PlanError::Usage(error)) => error.exit(),
         Err(entry::PlanError::Fatal(error)) => {
             eprintln!("{error:#}");

--- a/crates/omnia/src/runtime/entry.rs
+++ b/crates/omnia/src/runtime/entry.rs
@@ -10,8 +10,10 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
+#[cfg(feature = "cli")]
 use clap::Parser as _;
 
+#[cfg(feature = "cli")]
 use crate::cli::{Cli, Command};
 use crate::dispatch::{GuestResolver, HttpPaths};
 use crate::registry::GuestId;
@@ -150,6 +152,7 @@ pub(super) enum PlanError {
     /// A clap-level outcome (usage error, `--help`, `--version`); the caller
     /// delegates to [`clap::Error::exit`] so stream and exit code match the
     /// standard CLI behavior.
+    #[cfg(feature = "cli")]
     Usage(clap::Error),
     /// A startup failure reported on stderr.
     Fatal(anyhow::Error),
@@ -237,6 +240,8 @@ fn peel_log_flags(args: Vec<String>) -> Result<(Vec<String>, LogMode)> {
 /// On the direct-command path the plan always carries either the compiled-in
 /// manifest or the dynamic mark, so the builder never falls through to its
 /// own `OMNIA_CONFIG` lookup — the environment is untouched by design.
+// Without `cli`, `omnia_config` is only acknowledged, never consumed.
+#[cfg_attr(not(feature = "cli"), allow(clippy::needless_pass_by_value))]
 pub(super) fn plan(
     options: MainOptions, argv: impl IntoIterator<Item = OsString>, omnia_config: Option<OsString>,
 ) -> Result<EntryPlan, PlanError> {
@@ -282,6 +287,17 @@ pub(super) fn plan(
                 log_mode: Some(log_mode),
             })
         }
+        // Without the `cli` feature the standard grammar cannot be parsed;
+        // only direct-command deployments are entry points.
+        #[cfg(not(feature = "cli"))]
+        Invocation::OmniaCli => {
+            let _ = omnia_config;
+            Err(PlanError::Fatal(anyhow!(
+                "this runtime was built without omnia's `cli` feature; use the `runtime!` \
+                 macro's `program:` key or enable the feature"
+            )))
+        }
+        #[cfg(feature = "cli")]
         Invocation::OmniaCli => {
             let cli = Cli::try_parse_from(argv).map_err(PlanError::Usage)?;
             match cli.command {
@@ -363,6 +379,7 @@ mod tests {
         plan.manifest.as_ref().expect("plan carries a manifest").guests[0].id.as_str()
     }
 
+    #[cfg(feature = "cli")]
     fn temp_manifest(tag: &str, guest: &str) -> PathBuf {
         let path =
             std::env::temp_dir().join(format!("omnia_entry_{tag}_{}.toml", std::process::id()));
@@ -374,10 +391,12 @@ mod tests {
     fn fatal(error: PlanError) -> String {
         match error {
             PlanError::Fatal(error) => format!("{error:#}"),
+            #[cfg(feature = "cli")]
             PlanError::Usage(error) => panic!("expected a fatal error, got usage: {error}"),
         }
     }
 
+    #[cfg(feature = "cli")]
     #[test]
     fn config_beats_positional_wasm_and_compiled_source() {
         let path = temp_manifest("precedence", "from_config");
@@ -392,6 +411,7 @@ mod tests {
         assert_eq!(first_guest(&plan), "from_config");
     }
 
+    #[cfg(feature = "cli")]
     #[test]
     fn omnia_config_env_beats_positional_wasm() {
         let path = temp_manifest("env", "from_env");
@@ -405,6 +425,7 @@ mod tests {
         assert_eq!(first_guest(&plan), "from_env");
     }
 
+    #[cfg(feature = "cli")]
     #[test]
     fn positional_wasm_beats_compiled_source() {
         let options = MainOptions::new(Mode::Server).manifest(inline_source("compiled"));
@@ -413,6 +434,7 @@ mod tests {
         assert_eq!(first_guest(&plan), "guest");
     }
 
+    #[cfg(feature = "cli")]
     #[test]
     fn compiled_source_is_the_fallback() {
         let options = MainOptions::new(Mode::Server).manifest(inline_source("compiled"));
@@ -421,6 +443,7 @@ mod tests {
         assert_eq!(first_guest(&plan), "compiled");
     }
 
+    #[cfg(feature = "cli")]
     #[test]
     fn no_source_and_no_resolver_fails() {
         let error = plan(MainOptions::new(Mode::Server), argv(&["bin", "run"]), None)
@@ -429,6 +452,7 @@ mod tests {
         assert!(fatal(error).contains("no guest specified"));
     }
 
+    #[cfg(feature = "cli")]
     #[test]
     fn resolver_marks_dynamic_on_every_source() {
         // No source at all: the deployment starts empty rather than erroring.
@@ -494,6 +518,7 @@ mod tests {
         assert!(fatal(error).contains("mutually exclusive"));
     }
 
+    #[cfg(feature = "cli")]
     #[test]
     fn omnia_cli_carries_no_log_mode() {
         let options = MainOptions::new(Mode::Server).manifest(inline_source("compiled"));
@@ -543,6 +568,7 @@ mod tests {
         assert!(fatal(error).contains("compiled-in manifest or a resolver"));
     }
 
+    #[cfg(feature = "cli")]
     #[test]
     fn compiled_path_load_failure_surfaces() {
         let options = MainOptions::new(Mode::Server)
@@ -553,6 +579,7 @@ mod tests {
         assert!(fatal(error).contains("reading manifest"));
     }
 
+    #[cfg(feature = "cli")]
     #[test]
     fn usage_error_is_delegated_to_clap() {
         let error = plan(MainOptions::new(Mode::Server), argv(&["bin", "bogus"]), None)

--- a/crates/omnia/src/telemetry.rs
+++ b/crates/omnia/src/telemetry.rs
@@ -10,16 +10,27 @@
 //! the runtime does this at the end of every drive.
 
 use std::env;
-use std::sync::{Mutex, OnceLock, PoisonError};
+#[cfg(feature = "otlp")]
+use std::sync::OnceLock;
+use std::sync::{Mutex, PoisonError};
 
-use anyhow::{Result, anyhow};
+use anyhow::Result;
+#[cfg(feature = "otlp")]
+use anyhow::anyhow;
+#[cfg(feature = "otlp")]
 use opentelemetry::trace::TracerProvider;
+#[cfg(feature = "otlp")]
 use opentelemetry::{KeyValue, global};
+#[cfg(feature = "otlp")]
 use opentelemetry_otlp::{MetricExporter, SpanExporter, WithExportConfig};
 use opentelemetry_sdk::Resource;
+#[cfg(feature = "otlp")]
 use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
+#[cfg(feature = "otlp")]
 use opentelemetry_sdk::metrics::SdkMeterProvider;
+#[cfg(feature = "otlp")]
 use opentelemetry_sdk::trace::SdkTracerProvider;
+#[cfg(feature = "otlp")]
 use tracing_opentelemetry::MetricsLayer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -27,6 +38,7 @@ use tracing_subscriber::{EnvFilter, Registry};
 
 // The process's telemetry state. Like the global subscriber that references
 // the providers, it lives for the rest of the process.
+#[cfg(feature = "otlp")]
 static INSTALLED: OnceLock<Installed> = OnceLock::new();
 
 // Serializes first-time initialization. The `OnceLock` alone cannot: `build`
@@ -34,6 +46,7 @@ static INSTALLED: OnceLock<Installed> = OnceLock::new();
 // both pass the empty check and race on `try_init`.
 static INIT: Mutex<()> = Mutex::new(());
 
+#[cfg(feature = "otlp")]
 const UNKNOWN: &str = "unknown";
 
 /// Log preset selecting the subscriber's filter.
@@ -57,10 +70,12 @@ pub enum LogMode {
 pub struct Telemetry {
     /// The name of the application to for the purposes of identifying the
     /// service in telemetry data.
+    #[cfg_attr(not(feature = "otlp"), allow(dead_code))]
     app_name: String,
 
     /// OTLP gRPC endpoint override; unset defers to OpenTelemetry endpoint
     /// resolution (`OTEL_EXPORTER_OTLP_*` env vars, then `http://localhost:4317`).
+    #[cfg_attr(not(feature = "otlp"), allow(dead_code))]
     endpoint: Option<String>,
 
     /// Log preset for the subscriber's filter; unset defers to `RUST_LOG`.
@@ -107,52 +122,69 @@ impl Telemetry {
     /// subscriber fails.
     pub fn build(self) -> Result<()> {
         let _init = INIT.lock().unwrap_or_else(PoisonError::into_inner);
-        if INSTALLED.get().is_some() {
-            return Ok(());
-        }
 
-        let resource = self.resource();
-        let meter_provider = self.build_metrics(resource.clone())?;
-        let tracer_provider = self.build_traces(resource.clone())?;
-
-        let filter_layer = filter(self.log_mode)?;
-
-        // Console tracing goes to stderr: stdout belongs to the guest's
-        // semantic output (command mode pipes and JSON envelopes must stay
-        // clean of log lines).
-        let fmt_layer = tracing_subscriber::fmt::layer().with_writer(std::io::stderr);
-        let tracer = tracer_provider.tracer(self.app_name);
-        let tracing_layer = tracing_opentelemetry::layer().with_tracer(tracer);
-        let metrics_layer = MetricsLayer::new(meter_provider.clone());
-
-        // Install the subscriber before publishing providers globally so a
-        // failed try_init does not leave orphaned globals that later builds
-        // would retry against. An already-set subscriber (an embedder's own
-        // tracing setup) is tolerated: their subscriber stays, omnia's
-        // exporters are skipped, and the runtime keeps running.
-        if let Err(error) = Registry::default()
-            .with(filter_layer)
-            .with(fmt_layer)
-            .with(tracing_layer)
-            .with(metrics_layer)
-            .try_init()
+        #[cfg(feature = "otlp")]
         {
-            tracing::warn!(%error, "a tracing subscriber is already set; omnia telemetry skipped");
-            return Ok(());
+            if INSTALLED.get().is_some() {
+                return Ok(());
+            }
+
+            let resource = self.resource();
+            let meter_provider = self.build_metrics(resource.clone())?;
+            let tracer_provider = self.build_traces(resource.clone())?;
+
+            let filter_layer = filter(self.log_mode)?;
+
+            // Console tracing goes to stderr: stdout belongs to the guest's
+            // semantic output (command mode pipes and JSON envelopes must stay
+            // clean of log lines).
+            let fmt_layer = tracing_subscriber::fmt::layer().with_writer(std::io::stderr);
+            let tracer = tracer_provider.tracer(self.app_name);
+            let tracing_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+            let metrics_layer = MetricsLayer::new(meter_provider.clone());
+
+            // Install the subscriber before publishing providers globally so a
+            // failed try_init does not leave orphaned globals that later builds
+            // would retry against. An already-set subscriber (an embedder's own
+            // tracing setup) is tolerated: their subscriber stays, omnia's
+            // exporters are skipped, and the runtime keeps running.
+            if let Err(error) = Registry::default()
+                .with(filter_layer)
+                .with(fmt_layer)
+                .with(tracing_layer)
+                .with(metrics_layer)
+                .try_init()
+            {
+                tracing::warn!(%error, "a tracing subscriber is already set; omnia telemetry skipped");
+                return Ok(());
+            }
+
+            global::set_meter_provider(meter_provider.clone());
+            global::set_tracer_provider(tracer_provider.clone());
+
+            INSTALLED
+                .set(Installed {
+                    resource,
+                    tracer: tracer_provider,
+                    meter: meter_provider,
+                })
+                .map_err(|_installed| anyhow!("telemetry providers already installed"))
         }
 
-        global::set_meter_provider(meter_provider.clone());
-        global::set_tracer_provider(tracer_provider.clone());
-
-        INSTALLED
-            .set(Installed {
-                resource,
-                tracer: tracer_provider,
-                meter: meter_provider,
-            })
-            .map_err(|_installed| anyhow!("telemetry providers already installed"))
+        // Without the `otlp` feature there are no providers to install: the
+        // subscriber (filter + fmt) is the whole initialization.
+        #[cfg(not(feature = "otlp"))]
+        {
+            let filter_layer = filter(self.log_mode)?;
+            let fmt_layer = tracing_subscriber::fmt::layer().with_writer(std::io::stderr);
+            if let Err(error) = Registry::default().with(filter_layer).with(fmt_layer).try_init() {
+                tracing::warn!(%error, "a tracing subscriber is already set; omnia telemetry skipped");
+            }
+            Ok(())
+        }
     }
 
+    #[cfg(feature = "otlp")]
     fn build_traces(&self, resource: Resource) -> Result<SdkTracerProvider> {
         let mut exporter = SpanExporter::builder().with_tonic();
         if let Some(endpoint) = &self.endpoint {
@@ -165,6 +197,7 @@ impl Telemetry {
             .build())
     }
 
+    #[cfg(feature = "otlp")]
     fn build_metrics(&self, resource: Resource) -> Result<SdkMeterProvider> {
         let mut exporter = MetricExporter::builder().with_tonic();
         if let Some(endpoint) = &self.endpoint {
@@ -177,6 +210,7 @@ impl Telemetry {
             .build())
     }
 
+    #[cfg(feature = "otlp")]
     fn resource(&self) -> Resource {
         Resource::builder()
             .with_service_name(self.app_name.clone())
@@ -226,6 +260,7 @@ fn filter(mode: Option<LogMode>) -> Result<EnvFilter> {
 }
 
 // The process's resource and provider handles.
+#[cfg(feature = "otlp")]
 struct Installed {
     resource: Resource,
     tracer: SdkTracerProvider,
@@ -234,6 +269,7 @@ struct Installed {
 
 // Force-flush (not shut down) both providers, so telemetry keeps exporting
 // afterwards and repeated flushes are safe.
+#[cfg(feature = "otlp")]
 fn flush_providers(tracer: &SdkTracerProvider, meter: &SdkMeterProvider) {
     settle("traces", tracer.force_flush());
     settle("metrics", meter.force_flush());
@@ -241,6 +277,7 @@ fn flush_providers(tracer: &SdkTracerProvider, meter: &SdkMeterProvider) {
 
 // Report a flush failure without panicking; a provider that is already shut
 // down has nothing left to flush.
+#[cfg(feature = "otlp")]
 fn settle(signal: &str, result: OTelSdkResult) {
     match result {
         Ok(()) | Err(OTelSdkError::AlreadyShutdown) => {}
@@ -255,41 +292,62 @@ fn settle(signal: &str, result: OTelSdkResult) {
 /// are safe — the runtime calls it at the end of every drive so queued spans
 /// and metrics survive fast command-mode exits; embedders driving work
 /// themselves should call it before the process exits.
+#[cfg_attr(not(feature = "otlp"), allow(clippy::missing_const_for_fn))]
 pub fn flush() {
+    #[cfg(feature = "otlp")]
     if let Some(installed) = INSTALLED.get() {
         flush_providers(&installed.tracer, &installed.meter);
     }
 }
 
-/// Returns the OpenTelemetry [`Resource`] used to initialize telemetry for a
-/// service, or `None` if telemetry has not been initialized.
+/// Returns the OpenTelemetry [`Resource`] used to initialize telemetry.
+///
+/// `None` when telemetry has not been initialized — always the case without
+/// the `otlp` feature, which builds no providers.
+#[must_use]
+#[cfg_attr(not(feature = "otlp"), allow(clippy::missing_const_for_fn))]
 pub fn resource() -> Option<&'static Resource> {
-    INSTALLED.get().map(|installed| &installed.resource)
+    #[cfg(feature = "otlp")]
+    {
+        INSTALLED.get().map(|installed| &installed.resource)
+    }
+    #[cfg(not(feature = "otlp"))]
+    {
+        None
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "otlp")]
     use std::sync::{Arc, Mutex};
 
+    #[cfg(feature = "otlp")]
     use opentelemetry::trace::{Tracer as _, TracerProvider as _};
+    #[cfg(feature = "otlp")]
     use opentelemetry_sdk::metrics::SdkMeterProvider;
+    #[cfg(feature = "otlp")]
     use opentelemetry_sdk::trace::{SdkTracerProvider, SpanData, SpanExporter};
 
+    #[cfg(feature = "otlp")]
     use super::{OTelSdkResult, flush_providers};
 
     // A span exporter that keeps its records, so flushing is observable
     // without a collector.
+    #[cfg(feature = "otlp")]
     #[derive(Clone, Debug, Default)]
     struct Recording {
         names: Arc<Mutex<Vec<String>>>,
     }
 
+    #[cfg(feature = "otlp")]
     impl Recording {
         fn names(&self) -> Vec<String> {
             self.names.lock().expect("recording lock").clone()
         }
     }
 
+    #[cfg(feature = "otlp")]
     impl SpanExporter for Recording {
         async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
             self.names
@@ -302,6 +360,7 @@ mod tests {
 
     // A batch-exported provider set: spans stay queued (5s schedule delay)
     // until a flush pushes them, so flush behavior is what the test sees.
+    #[cfg(feature = "otlp")]
     fn providers(exporter: &Recording) -> (SdkTracerProvider, SdkMeterProvider) {
         (
             SdkTracerProvider::builder().with_batch_exporter(exporter.clone()).build(),
@@ -355,6 +414,7 @@ mod tests {
 
     // The fast-exit contract: a span emitted immediately before a flush
     // reaches the exporter, and export keeps working after the flush.
+    #[cfg(feature = "otlp")]
     #[test]
     fn flush_exports_queued_spans() {
         let exporter = Recording::default();

--- a/crates/wasi-http/Cargo.toml
+++ b/crates/wasi-http/Cargo.toml
@@ -28,7 +28,12 @@ fromenv.workspace = true
 futures.workspace = true
 http-body-util.workspace = true
 hyper.workspace = true
-reqwest = { version = "0.13.4", features = ["stream"] }
+# `rustls-no-provider` keeps TLS (and `Identity::from_pem`) without reqwest's
+# default `aws-lc-sys` provider — `ring` is already in the tree via
+# wasmtime-wasi-http. The default backend installs ring as the process
+# provider before building a client (see `host/default_impl.rs`).
+reqwest = { version = "0.13.4", default-features = false, features = ["http2", "rustls-no-provider", "stream", "system-proxy"] }
+rustls = { version = "0.23.42", default-features = false, features = ["ring", "std"] }
 tokio = { workspace = true, features = ["time"] }
 wasmtime = { workspace = true, features = ["component-model-async"] }
 wasmtime-wasi.workspace = true

--- a/crates/wasi-http/src/host/default_impl.rs
+++ b/crates/wasi-http/src/host/default_impl.rs
@@ -77,11 +77,23 @@ impl HttpDefault {
     }
 }
 
+// reqwest is built with `rustls-no-provider` (keeping `aws-lc-sys` out of the
+// tree), which requires a process-level crypto provider before a client is
+// built. Ring is the provider wasmtime-wasi-http already links; an embedder
+// that installed its own provider first wins, and losing an install race
+// still leaves exactly one default in place.
+fn ensure_crypto_provider() {
+    if rustls::crypto::CryptoProvider::get_default().is_none() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+}
+
 impl Backend for HttpDefault {
     type ConnectOptions = ConnectOptions;
 
     #[instrument]
     async fn connect_with(options: Self::ConnectOptions) -> Result<Self> {
+        ensure_crypto_provider();
         let connect_timeout = Duration::from_secs(options.connect_timeout);
         let builder = reqwest::Client::builder().connect_timeout(connect_timeout);
         let client = builder.build().context("building HTTP client")?;

--- a/crates/wasi-identity/Cargo.toml
+++ b/crates/wasi-identity/Cargo.toml
@@ -15,12 +15,20 @@ version.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = ["oauth"]
+
+# Enables the OAuth2 client-credentials default backend (`IdentityDefault`).
+# Without it the host surface and `IdentityStub` stay; disabling drops the
+# `oauth2` crate and its bundled reqwest/TLS stack.
+oauth = ["dep:fromenv", "dep:oauth2"]
+
 # host dependencies
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 anyhow.workspace = true
-fromenv.workspace = true
+fromenv = { workspace = true, optional = true }
 futures.workspace = true
-oauth2 = "5.0.0"
+oauth2 = { version = "5.0.0", optional = true }
 omnia.workspace = true
 serde.workspace = true
 tracing.workspace = true

--- a/crates/wasi-identity/README.md
+++ b/crates/wasi-identity/README.md
@@ -10,6 +10,10 @@ Implements the `wasi:identity` WIT interface.
 
 - **Default**: Uses `oauth2` crate to interact with OAuth2/OIDC providers.
 
+## Cargo features
+
+- `oauth` *(default)*: the `OAuth2` client-credentials default backend (`IdentityDefault`). Disable it (`default-features = false`) when supplying your own `WasiIdentityCtx` backend to skip compiling `oauth2` and its bundled HTTP/TLS stack.
+
 ## Configuration
 
 Requires configuration via environment variables or other sources to set provider details (Client ID, Client Secret, etc.).

--- a/crates/wasi-identity/src/host.rs
+++ b/crates/wasi-identity/src/host.rs
@@ -3,6 +3,7 @@
 //! This module implements the host-side logic for the WASI Identity service.
 
 mod credentials_impl;
+#[cfg(feature = "oauth")]
 mod default_impl;
 mod resource;
 mod stub_impl;
@@ -34,6 +35,7 @@ pub use omnia::FutureResult;
 use omnia::{Host, Server};
 use wasmtime::component::{HasData, Linker};
 
+#[cfg(feature = "oauth")]
 pub use self::default_impl::IdentityDefault;
 use self::generated::omnia::identity::credentials;
 pub use self::resource::*;

--- a/crates/wasi-identity/src/host/stub_impl.rs
+++ b/crates/wasi-identity/src/host/stub_impl.rs
@@ -11,7 +11,8 @@ use crate::host::resource::{FutureResult, Identity};
 /// Credential-free `wasi:identity` backend returning a fixed token.
 ///
 /// For tests and local development where no identity provider is available;
-/// production deployments use [`super::IdentityDefault`] or a backend crate.
+/// production deployments use `IdentityDefault` (the `oauth` feature) or a
+/// backend crate.
 #[derive(Debug, Clone, Default)]
 pub struct IdentityStub;
 

--- a/crates/wasi-sql/Cargo.toml
+++ b/crates/wasi-sql/Cargo.toml
@@ -15,14 +15,21 @@ version.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = ["sqlite"]
+
+# Enables the bundled-SQLite default backend (`SqlDefault`). Without it the
+# host surface stays; embedders supply their own `WasiSqlCtx`.
+sqlite = ["dep:fromenv", "dep:futures", "dep:parking_lot", "dep:rusqlite", "dep:tokio"]
+
 # host dependencies
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-fromenv.workspace = true
-futures.workspace = true
+fromenv = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
 omnia.workspace = true
-parking_lot.workspace = true
-rusqlite = { version = "0.40.1", features = ["bundled"] }
-tokio = { workspace = true, features = ["rt"] }
+parking_lot = { workspace = true, optional = true }
+rusqlite = { version = "0.40.1", features = ["bundled"], optional = true }
+tokio = { workspace = true, features = ["rt"], optional = true }
 wasmtime.workspace = true
 wasmtime-wasi.workspace = true
 

--- a/crates/wasi-sql/README.md
+++ b/crates/wasi-sql/README.md
@@ -10,6 +10,10 @@ Implements the `wasi:sql` WIT interface.
 
 - **Host**: Uses `rusqlite` to provide a `SQLite` backend. Supports both in-memory (`:memory:`) and file-based databases.
 
+## Cargo features
+
+- `sqlite` *(default)*: the bundled-SQLite default backend (`SqlDefault`). Disable it (`default-features = false`) when supplying your own `WasiSqlCtx` backend to skip compiling bundled `SQLite`.
+
 ## Features
 
 ### Guest ORM Layer

--- a/crates/wasi-sql/src/host.rs
+++ b/crates/wasi-sql/src/host.rs
@@ -2,6 +2,7 @@
 //!
 //! This module implements the host-side logic for the WASI SQL service.
 
+#[cfg(feature = "sqlite")]
 mod default_impl;
 mod readwrite_impl;
 mod resource;
@@ -37,6 +38,7 @@ use omnia::{Host, Server};
 use wasmtime::component::{HasData, Linker};
 
 use self::generated::wasi::sql::{readwrite, types};
+#[cfg(feature = "sqlite")]
 pub use crate::host::default_impl::SqlDefault;
 pub use crate::host::generated::wasi::sql::types::{DataType, Field, Row};
 pub use crate::host::resource::*;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Feature gating touches runtime entry, telemetry, and TLS for outbound HTTP; defaults preserve prior behavior, but custom builds that disable `cli` or `otlp` change startup and observability paths.
> 
> **Overview**
> Introduces **Cargo feature flags** across the workspace so embedders and guests can drop heavy optional stacks (CLI, SQL ORM, OTLP export, OAuth identity, bundled SQLite) without forking crates.
> 
> **`omnia`** gains `cli`, `otlp`, and expanded defaults (`cli`, `jit`, `otlp`). Without `cli`, the generated `main` only supports `runtime!` **direct-command** / `program:` entry; without `otlp`, telemetry installs stderr fmt + filters only and `flush` / `resource` are no-ops. OTLP is wired through tonic-only `opentelemetry-otlp` (no unused HTTP/reqwest export path).
> 
> **`omnia-guest`** splits **`cli`** (clap command router) and **`orm`** (ORM, table/document capabilities, docstore re-exports); both default on.
> 
> **WASI host crates**: **`omnia-wasi-sql`** (`sqlite`), **`omnia-wasi-identity`** (`oauth`), with default backends gated behind those features.
> 
> **`omnia-wasi-http`** trims reqwest to `rustls-no-provider` + explicit **ring** install before client build, removing **`aws-lc-sys`** from the lockfile.
> 
> CI adds a **`features`** cargo-make task (clippy with `--no-default-features` and selective feature combos); **`test-seam`** is renamed **`seam`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3374aff44f62a46a147dec7305bd440cfa809b3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->