### PR TITLE
Workspace grants

### DIFF
--- a/crates/omnia-guest/src/capabilities/model.rs
+++ b/crates/omnia-guest/src/capabilities/model.rs
@@ -3,9 +3,11 @@
 //! Target-independent mirrors of the `omnia:model/completion` records. The
 //! one record that cannot cross off `wasm32` is the `grants.workspace`
 //! descriptor lend — a `wasi:filesystem` resource that only exists on
-//! `wasm32` — so a guest asks for it with the plain
-//! [`Request::lend_workspace`] flag and the `wasm32` default body resolves
-//! it against the guest's own `"."` preopen at the call site.
+//! `wasm32` — so a guest names the directory with the plain
+//! [`Request::workspace`] path and the `wasm32` default body resolves it
+//! against the guest's preopens at the call site: the longest preopen whose
+//! name prefixes the path becomes the lent root descriptor and the
+//! remainder rides as the grant's subpath.
 
 use std::future::Future;
 
@@ -151,10 +153,14 @@ pub struct Request {
     /// targets (`grants.references`).
     #[builder(into)]
     pub references: Option<String>,
-    /// Lend the guest's `"."` preopen through `grants.workspace`, giving the
-    /// backend (and any spawned agent) the shared project mount.
-    #[builder(default)]
-    pub lend_workspace: bool,
+    /// Deployment-local path of the directory to lend through
+    /// `grants.workspace`, giving the backend (and any spawned agent) that
+    /// directory. On `wasm32` the path must sit on (or beneath) a preopen —
+    /// `"."` lends the shared project mount, `"/mount/sub"` lends a
+    /// subdirectory of `/mount`. Off `wasm32` it is a host path the
+    /// provider consumes directly. `None` lends nothing.
+    #[builder(into)]
+    pub workspace: Option<String>,
 }
 
 /// Token accounting for one completion, when the backend reports it.
@@ -219,13 +225,20 @@ pub trait Model: Send + Sync {
             // The lent workspace borrows one of these descriptors, so the
             // table must outlive the `create` call below.
             let directories =
-                if request.lend_workspace { preopens::get_directories() } else { vec![] };
-            let workspace = directories.iter().find_map(|(dir, name)| (name == ".").then_some(dir));
-            if request.lend_workspace && workspace.is_none() {
-                return Err(Error::InvalidRequest(
-                    "workspace lend requested but the `.` preopen is absent".to_string(),
-                ));
-            }
+                if request.workspace.is_some() { preopens::get_directories() } else { vec![] };
+            let workspace = match request.workspace.as_deref() {
+                None => None,
+                Some(path) => match resolve_lend(&directories, path) {
+                    Some((root, subpath)) => {
+                        Some(completion::WorkspaceGrant { root, subpath: subpath.to_string() })
+                    }
+                    None => {
+                        return Err(Error::InvalidRequest(format!(
+                            "workspace lend `{path}` matches no preopen"
+                        )));
+                    }
+                },
+            };
 
             let wire = completion::Request {
                 model: request.model,
@@ -242,6 +255,59 @@ pub trait Model: Send + Sync {
 
             completion::create(wire).await.map(Into::into).map_err(Into::into)
         }
+    }
+}
+
+/// Resolve a lend path against the guest's preopens: the longest preopen
+/// name that equals the path or prefixes it at a `/` boundary wins; the
+/// remainder becomes the grant's subpath (empty for the mount itself).
+#[cfg(any(target_arch = "wasm32", test))]
+fn resolve_lend<'a, D>(directories: &'a [(D, String)], path: &'a str) -> Option<(&'a D, &'a str)> {
+    directories
+        .iter()
+        .filter_map(|(dir, name)| Some((dir, lend_subpath(name, path)?)))
+        .max_by_key(|(_, subpath)| std::cmp::Reverse(subpath.len()))
+}
+
+/// The subpath of `path` beneath the preopen `name`, when `name` covers it.
+#[cfg(any(target_arch = "wasm32", test))]
+fn lend_subpath<'a>(name: &str, path: &'a str) -> Option<&'a str> {
+    if path == name {
+        return Some("");
+    }
+    path.strip_prefix(name)?.strip_prefix('/').filter(|rest| !rest.is_empty())
+}
+
+// The lend resolution is pure path math that only executes on `wasm32`
+// (preopens exist nowhere else), so it is covered in-process here.
+#[cfg(test)]
+mod tests {
+    use super::resolve_lend;
+
+    fn preopens() -> Vec<((), String)> {
+        vec![((), ".".to_string()), ((), "/emery-workspaces".to_string())]
+    }
+
+    #[test]
+    fn resolves_mount_and_subdirectory() {
+        let dirs = preopens();
+        assert_eq!(resolve_lend(&dirs, ".").map(|(_, sub)| sub), Some(""));
+        assert_eq!(
+            resolve_lend(&dirs, "/emery-workspaces/ws-1").map(|(_, sub)| sub),
+            Some("ws-1")
+        );
+        assert_eq!(
+            resolve_lend(&dirs, "/emery-workspaces/ws-1/nested").map(|(_, sub)| sub),
+            Some("ws-1/nested")
+        );
+    }
+
+    #[test]
+    fn refuses_unmatched_and_lookalike_paths() {
+        let dirs = preopens();
+        assert!(resolve_lend(&dirs, "/elsewhere").is_none());
+        assert!(resolve_lend(&dirs, "/emery-workspaces-evil/x").is_none());
+        assert!(resolve_lend(&dirs, "/emery-workspaces/").is_none());
     }
 }
 

--- a/crates/omnia-guest/src/capabilities/model.rs
+++ b/crates/omnia-guest/src/capabilities/model.rs
@@ -285,8 +285,8 @@ fn lend_subpath<'a>(name: &str, path: &'a str) -> Option<&'a str> {
 mod tests {
     use super::resolve_lend;
 
-    fn preopens() -> Vec<((), String)> {
-        vec![((), ".".to_string()), ((), "/emery-workspaces".to_string())]
+    fn preopens() -> Vec<(u8, String)> {
+        vec![(0, ".".to_string()), (1, "/emery-workspaces".to_string())]
     }
 
     #[test]

--- a/crates/omnia-guest/src/capabilities/model.rs
+++ b/crates/omnia-guest/src/capabilities/model.rs
@@ -229,9 +229,10 @@ pub trait Model: Send + Sync {
             let workspace = match request.workspace.as_deref() {
                 None => None,
                 Some(path) => match resolve_lend(&directories, path) {
-                    Some((root, subpath)) => {
-                        Some(completion::WorkspaceGrant { root, subpath: subpath.to_string() })
-                    }
+                    Some((root, subpath)) => Some(completion::WorkspaceGrant {
+                        root,
+                        subpath: subpath.to_string(),
+                    }),
                     None => {
                         return Err(Error::InvalidRequest(format!(
                             "workspace lend `{path}` matches no preopen"
@@ -292,10 +293,7 @@ mod tests {
     fn resolves_mount_and_subdirectory() {
         let dirs = preopens();
         assert_eq!(resolve_lend(&dirs, ".").map(|(_, sub)| sub), Some(""));
-        assert_eq!(
-            resolve_lend(&dirs, "/emery-workspaces/ws-1").map(|(_, sub)| sub),
-            Some("ws-1")
-        );
+        assert_eq!(resolve_lend(&dirs, "/emery-workspaces/ws-1").map(|(_, sub)| sub), Some("ws-1"));
         assert_eq!(
             resolve_lend(&dirs, "/emery-workspaces/ws-1/nested").map(|(_, sub)| sub),
             Some("ws-1/nested")

--- a/crates/wasi-model/src/host.rs
+++ b/crates/wasi-model/src/host.rs
@@ -42,7 +42,7 @@ pub use self::gate::validate as validate_request;
 use self::generated::omnia::model::completion;
 pub use self::generated::omnia::model::completion::{
     Effort, Error, Format, Function, Generation, Grants, Mcp, Message, Reply, Request, Role,
-    Schema, Tool,
+    Schema, Tool, WorkspaceGrant,
 };
 pub use self::types::{Answer, DirEntry, Reference, ToolTurn, Transcript, Usage};
 

--- a/crates/wasi-model/src/host/workspace.rs
+++ b/crates/wasi-model/src/host/workspace.rs
@@ -1,10 +1,12 @@
 //! Workspace resolution in the host.
 //!
 //! A guest lends a `wasi:filesystem` workspace through
-//! `grants.workspace: option<borrow<descriptor>>`. This module turns that
-//! borrowed descriptor into an owned, `Send + Sync` [`Workspace`] the backend
-//! can use across `.await` points, *after* proving the lent directory is one the
-//! deployment authorized.
+//! `grants.workspace: option<workspace-grant>` — a borrowed mount-root
+//! descriptor plus a relative subpath. This module turns that grant into an
+//! owned, `Send + Sync` [`Workspace`] the backend can use across `.await`
+//! points, *after* proving the lent root is one the deployment authorized
+//! and reopening the subpath beneath it so the lend can never escape the
+//! mount.
 
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
@@ -16,9 +18,10 @@ use cap_std::fs::Dir;
 use futures::FutureExt as _;
 use omnia::{FutureResult, MountRegistry};
 use tokio::task::spawn_blocking;
-use wasmtime::component::{Resource, ResourceTable};
+use wasmtime::component::ResourceTable;
 use wasmtime_wasi::filesystem::Descriptor;
 
+use super::generated::omnia::model::completion::WorkspaceGrant;
 use super::types::DirEntry;
 
 const MAX_READ_BYTES: u64 = 4 * 1024 * 1024;
@@ -71,28 +74,55 @@ fn ready_err<R: Send + 'static>(err: anyhow::Error) -> FutureResult<R> {
 
 // Resolve a `grants.workspace` into a [`Workspace`].
 pub fn resolve(
-    table: &ResourceTable, registry: &MountRegistry, borrow: Option<&Resource<Descriptor>>,
+    table: &ResourceTable, registry: &MountRegistry, grant: Option<&WorkspaceGrant>,
 ) -> anyhow::Result<Option<Workspace>> {
-    let Some(resource) = borrow else {
+    let Some(grant) = grant else {
         return Ok(None);
     };
 
-    let descriptor = table.get(resource).context("resolving the lent workspace descriptor")?;
+    let descriptor = table.get(&grant.root).context("resolving the lent workspace descriptor")?;
 
     let Descriptor::Dir(dir) = descriptor else {
-        bail!("grants.workspace must be a directory descriptor, not a file");
+        bail!("grants.workspace root must be a directory descriptor, not a file");
     };
 
     let meta = dir.dir.dir_metadata().context("reading lent workspace directory metadata")?;
     let entry = registry
         .match_identity(meta.dev(), meta.ino())
-        .context("lent workspace is not an authorized mount (out of scope)")?;
+        .context("lent workspace root is not an authorized mount (out of scope)")?;
+
+    if grant.subpath.is_empty() {
+        return Ok(Some(Workspace {
+            dir: Arc::clone(&entry.dir),
+            local_path: entry.host_path.clone(),
+            writable: entry.writable(),
+        }));
+    }
+
+    check_subpath(&grant.subpath)?;
+    // cap-std's `open_dir` resolves beneath the verified mount root and
+    // refuses any escape, so the subpath grant inherits the root's authority.
+    let dir = entry
+        .dir
+        .open_dir(&grant.subpath)
+        .with_context(|| format!("opening lent workspace subpath `{}`", grant.subpath))?;
 
     Ok(Some(Workspace {
-        dir: Arc::clone(&entry.dir),
-        local_path: entry.host_path.clone(),
+        dir: Arc::new(dir),
+        local_path: entry.host_path.join(&grant.subpath),
         writable: entry.writable(),
     }))
+}
+
+// Refuse a subpath that is not a plain relative `/`-separated path.
+fn check_subpath(subpath: &str) -> anyhow::Result<()> {
+    let plain = !subpath.starts_with('/')
+        && !subpath.contains('\\')
+        && subpath.split('/').all(|part| !part.is_empty() && part != "." && part != "..");
+    if plain {
+        return Ok(());
+    }
+    bail!("grants.workspace subpath `{subpath}` is not a plain relative path");
 }
 
 fn read_blocking(dir: &Dir, path: &str) -> anyhow::Result<Vec<u8>> {

--- a/crates/wasi-model/wit/model.wit
+++ b/crates/wasi-model/wit/model.wit
@@ -153,15 +153,27 @@ interface completion {
     //     named(string),
     // }
 
+    /// One lent workspace: an authorized mount root plus a relative
+    /// subpath scoping the lend to a directory beneath it.
+    record workspace-grant {
+        /// Typed `wasi:filesystem` capability for bounded `read` / `list` / `write`
+        /// (genai) and the spawned agent's direct access (cursor). A `borrow`, so the
+        /// runtime core never trusts a forgeable integer handle — the host resolves it
+        /// from the resource table exactly as other hosts take typed resources, and
+        /// requires it to be an authorized mount root.
+        root: borrow<descriptor>,
+        /// `/`-separated relative path beneath `root` scoping the lend; empty lends
+        /// the mount root itself. The host reopens it beneath the verified root, so
+        /// the grant can never escape the mount.
+        subpath: string,
+    }
+
     /// Host capabilities lent for this completion; drives host-injected tool injection.
     record grants {
         /// Guest id whose `references` export `resolve` targets.
         references: option<string>,
-        /// Typed `wasi:filesystem` capability for bounded `read` / `list` / `write`
-        /// (genai) and the spawned agent's direct access (cursor). A `borrow`, so the
-        /// The runtime core never trusts a forgeable integer handle — the host resolves it from
-        /// the resource table exactly as other hosts take typed resources.
-        workspace: option<borrow<descriptor>>,
+        /// The workspace lent for this completion.
+        workspace: option<workspace-grant>,
     }
 
     /// Complete models-API-style request for one completion. Guests that want a

--- a/examples/model/guest.rs
+++ b/examples/model/guest.rs
@@ -27,11 +27,17 @@ wasip3::cli::command::export!(CliGuest);
 impl Guest for CliGuest {
     async fn run() -> Result<(), ()> {
         // Read the preopen table the host populated from `[[mount]]` and
-        // pick the tree named `.` to lend. `directories` must outlive the
-        // `create` call below — the lent `workspace` borrows one of its
-        // descriptors.
+        // pick the tree named `.` to lend as the grant's root (with an
+        // empty subpath — the mount itself). `directories` must outlive
+        // the `create` call below — the lent `workspace` borrows one of
+        // its descriptors.
         let directories = preopens::get_directories();
-        let workspace = directories.iter().find_map(|(dir, name)| (name == ".").then_some(dir));
+        let workspace = directories.iter().find_map(|(dir, name)| {
+            (name == ".").then_some(completion::WorkspaceGrant {
+                root: dir,
+                subpath: String::new(),
+            })
+        });
 
         let (system, messages) = Sections {
             role: Some("a terse code reviewer".to_string()),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes workspace authorization and path resolution on the model completion boundary; subpath validation and cap-std reopening are the main escape controls, but this is security-adjacent filesystem lending logic.
> 
> **Overview**
> **Workspace lending is now path-scoped** instead of a boolean that only lent the `"."` preopen. Guests set `Request::workspace` to an optional deployment-local path; on `wasm32` the longest matching preopen becomes the grant root and the remainder is the subpath.
> 
> The WIT **`grants.workspace`** type changes from a bare borrowed directory descriptor to a **`workspace-grant`** record (`root` + relative `subpath`). The host verifies the root against authorized mounts, validates the subpath (no `..`, absolute paths, etc.), and reopens the subdirectory beneath the mount so the lend cannot escape the root.
> 
> Unit tests cover preopen matching and rejection of lookalike/unmatched paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20a117efe6b2493014065455be0c5a6d8a6b3cb2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->