### PR TITLE
wasi:model workspace grants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,9 +27,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -48,9 +48,9 @@ checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -277,7 +277,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes 3.0.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -294,7 +294,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
  "winx",
 ]
 
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -359,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -369,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -379,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.7"
+version = "4.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
 dependencies = [
  "clap",
 ]
@@ -410,7 +410,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -798,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "deadpool"
@@ -843,13 +843,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -907,7 +907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -964,9 +964,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -981,9 +981,9 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "fluent-uri"
@@ -1292,9 +1292,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1337,9 +1337,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -1607,9 +1607,9 @@ checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "itertools"
@@ -1638,7 +1638,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -1677,9 +1677,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1688,9 +1688,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.49.1"
+version = "0.49.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc9116a0f75b7336e55eb2a2a0ddef86c37cadf02924a571751aa123d5a0290"
+checksum = "ce93912abc8220a3fdb768b2c4a826a7a9a4b1599cfb4d760d422eaa1faf88c7"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1717,18 +1717,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.49.1"
+version = "0.49.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628a1f02bda4651d9a6088ee6386a92f0ee96255b0c99e9dfe1be91bf83bd838"
+checksum = "8165657ebed4d32c50f3c250c1986d8428b16fbfeac355222e8fec50aa26eb1d"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.49.1"
+version = "0.49.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75d94a372f8d81d070fd405065c6b1168d8248d1d6adad073ac708de254698c6"
+checksum = "b069c5fdda3e9c2242bba49d811d5bbdb488abd8d234ed44a6312fd2891113e1"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1781,9 +1781,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.38.1"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1922,7 +1922,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2108,7 +2108,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tower",
  "tracing",
@@ -2421,7 +2421,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -2436,7 +2436,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tonic",
  "tonic-types",
@@ -2471,7 +2471,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
 ]
@@ -2698,7 +2698,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -2720,7 +2720,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2737,7 +2737,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2906,9 +2906,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.49.1"
+version = "0.49.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978badf4419c9d0e1bc6e7466e99277f829d768257670c46d88121ca75e34bf7"
+checksum = "f39f4c36ce0f50e96fb740d895f1cad34cfa76c4ab5c36934d6590bcd7029087"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -2950,9 +2950,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3062,14 +3062,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "rusqlite"
-version = "0.40.1"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -3111,7 +3111,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3126,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "log",
  "once_cell",
@@ -3179,7 +3179,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3433,7 +3433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3578,7 +3578,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3601,11 +3601,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -3621,9 +3621,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3681,13 +3681,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3741,9 +3741,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3765,9 +3765,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -3977,9 +3977,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.118"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06649c6f63d86604ba0c8950d5a1829fc9a17afd70fc6629f481d75b6a624c78"
+checksum = "1e605bf6b39357663d8ba4e984f8be8da8df6bb32e81031d6889024ea8fd68e4"
 dependencies = [
  "glob",
  "serde",
@@ -4003,7 +4003,7 @@ dependencies = [
  "log",
  "rand 0.10.2",
  "sha1",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4168,15 +4168,15 @@ dependencies = [
  "bytes",
  "http",
  "http-body",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "wit-bindgen 0.57.1",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4187,9 +4187,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4197,9 +4197,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4207,9 +4207,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4220,9 +4220,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -4448,7 +4448,7 @@ dependencies = [
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "wasmparser 0.252.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
@@ -4546,7 +4546,7 @@ dependencies = [
  "io-lifetimes 3.0.1",
  "rand 0.10.2",
  "rustix",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -4613,9 +4613,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4656,7 +4656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89091642df051b84a7e00bdff75e985e507f2298384e477cc9310b0ddd79f004"
 dependencies = [
  "bitflags",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "wasmtime",
  "wasmtime-environ",
@@ -4695,7 +4695,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5129,7 +5129,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 [[package]]
 name = "wrpc-introspect"
 version = "0.7.0"
-source = "git+https://github.com/bytecodealliance/wrpc#52e5d7f13d5a1d9073bde734e01b27cd77202473"
+source = "git+https://github.com/bytecodealliance/wrpc#1198ffe66f409df7f63f511a727014e2e03afeac"
 dependencies = [
  "wit-parser 0.251.0",
 ]
@@ -5137,7 +5137,7 @@ dependencies = [
 [[package]]
 name = "wrpc-transport"
 version = "0.29.0"
-source = "git+https://github.com/bytecodealliance/wrpc#52e5d7f13d5a1d9073bde734e01b27cd77202473"
+source = "git+https://github.com/bytecodealliance/wrpc#1198ffe66f409df7f63f511a727014e2e03afeac"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5154,7 +5154,7 @@ dependencies = [
 [[package]]
 name = "wrpc-wasmtime"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wrpc#52e5d7f13d5a1d9073bde734e01b27cd77202473"
+source = "git+https://github.com/bytecodealliance/wrpc#1198ffe66f409df7f63f511a727014e2e03afeac"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5196,18 +5196,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,14 +67,14 @@ cap-fs-ext = "4.0.2"
 cap-std = "4.0.2"
 cfg-if = "1.0.4"
 chrono = "0.4.45"
-clap = { version = "4.6.4", default-features = false, features = ["derive", "error-context", "help", "std", "usage"] }
-clap_complete = "4.6.7"
+clap = { version = "4.6.6", default-features = false, features = ["derive", "error-context", "help", "std", "usage"] }
+clap_complete = "4.6.9"
 dashmap = "6.2.1"
 fromenv = "0.1.0"
 futures = "0.3.33"
 futures-channel = "0.3.33"
 futures-util = "0.3.33"
-http = "1.4.2"
+http = "1.5.0"
 http-body = "1.1.0"
 http-body-util = "0.1.4"
 hyper = "1.11.0"
@@ -82,7 +82,7 @@ hyper-util = "0.1.20"
 insta = "1.48.0"
 # Default features pull reqwest/rustls for remote `$ref` resolution; the gate
 # only validates self-contained schema documents.
-jsonschema = { version = "0.49.1", default-features = false }
+jsonschema = { version = "0.49.8", default-features = false }
 moka = { version = "0.12.15", features = ["sync"] }
 opentelemetry = "0.32.0"
 opentelemetry-proto = "0.32.0"
@@ -99,17 +99,17 @@ serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 serde_urlencoded = "0.7.1"
 syn = { version = "3.0.3", features = ["full"] }
-thiserror = "2.0.19"
+thiserror = "2.0.20"
 tokio = { version = "1.53.1", default-features = false }
 tokio-stream = { version = "0.1.19", features = ["sync"] }
 tokio-tungstenite = "0.30.0"
 tokio-util = { version = "0.7.19", features = ["codec"] }
-toml = { version = "1.1.3", default-features = false, features = ["parse", "serde", "std"] }
+toml = { version = "1.1.4", default-features = false, features = ["parse", "serde", "std"] }
 tower = "0.5.3"
 tracing = "0.1.44"
 tracing-opentelemetry = "0.33.0"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt"] }
-trybuild = "1.0.118"
+trybuild = "1.0.120"
 wasip3 = { version = "0.7.0", features = ["http-compat"] }
 # Pinned to match `wrpc`'s own dependency so the link-seam value codec stays
 # byte-identical with `wrpc-wasmtime`'s.

--- a/crates/omnia-guest/src/capabilities/blob.rs
+++ b/crates/omnia-guest/src/capabilities/blob.rs
@@ -153,6 +153,11 @@ pub trait BlobStore: Send + Sync {
         use anyhow::anyhow;
         use omnia_wasi_blobstore::types::OutgoingValue;
 
+        // `blocking-write-and-flush` permits at most 4096 bytes per
+        // call (the wasi:io stream write budget), so larger payloads
+        // must be written in chunks.
+        const WRITE_CHUNK: usize = 4096;
+
         async move {
             let ctr = open_container(container).await?;
             let outgoing = OutgoingValue::new_outgoing_value();
@@ -161,7 +166,10 @@ pub trait BlobStore: Send + Sync {
                     .outgoing_value_write_body()
                     .await
                     .map_err(|e| anyhow!("getting write body: {e:?}"))?;
-                body.blocking_write_and_flush(data).map_err(|e| anyhow!("writing data: {e}"))?;
+                for chunk in data.chunks(WRITE_CHUNK) {
+                    body.blocking_write_and_flush(chunk)
+                        .map_err(|e| anyhow!("writing data: {e}"))?;
+                }
             };
             ctr.write_data(name.to_string(), &outgoing)
                 .await

--- a/crates/omnia-guest/src/capabilities/model.rs
+++ b/crates/omnia-guest/src/capabilities/model.rs
@@ -3,9 +3,11 @@
 //! Target-independent mirrors of the `omnia:model/completion` records. The
 //! one record that cannot cross off `wasm32` is the `grants.workspace`
 //! descriptor lend — a `wasi:filesystem` resource that only exists on
-//! `wasm32` — so a guest asks for it with the plain
-//! [`Request::lend_workspace`] flag and the `wasm32` default body resolves
-//! it against the guest's own `"."` preopen at the call site.
+//! `wasm32` — so a guest names the directory with the plain
+//! [`Request::workspace`] path and the `wasm32` default body resolves it
+//! against the guest's preopens at the call site: the longest preopen whose
+//! name prefixes the path becomes the lent root descriptor and the
+//! remainder rides as the grant's subpath.
 
 use std::future::Future;
 
@@ -151,10 +153,14 @@ pub struct Request {
     /// targets (`grants.references`).
     #[builder(into)]
     pub references: Option<String>,
-    /// Lend the guest's `"."` preopen through `grants.workspace`, giving the
-    /// backend (and any spawned agent) the shared project mount.
-    #[builder(default)]
-    pub lend_workspace: bool,
+    /// Deployment-local path of the directory to lend through
+    /// `grants.workspace`, giving the backend (and any spawned agent) that
+    /// directory. On `wasm32` the path must sit on (or beneath) a preopen —
+    /// `"."` lends the shared project mount, `"/mount/sub"` lends a
+    /// subdirectory of `/mount`. Off `wasm32` it is a host path the
+    /// provider consumes directly. `None` lends nothing.
+    #[builder(into)]
+    pub workspace: Option<String>,
 }
 
 /// Token accounting for one completion, when the backend reports it.
@@ -219,13 +225,20 @@ pub trait Model: Send + Sync {
             // The lent workspace borrows one of these descriptors, so the
             // table must outlive the `create` call below.
             let directories =
-                if request.lend_workspace { preopens::get_directories() } else { vec![] };
-            let workspace = directories.iter().find_map(|(dir, name)| (name == ".").then_some(dir));
-            if request.lend_workspace && workspace.is_none() {
-                return Err(Error::InvalidRequest(
-                    "workspace lend requested but the `.` preopen is absent".to_string(),
-                ));
-            }
+                if request.workspace.is_some() { preopens::get_directories() } else { vec![] };
+            let workspace = match request.workspace.as_deref() {
+                None => None,
+                Some(path) => match resolve_lend(&directories, path) {
+                    Some((root, subpath)) => {
+                        Some(completion::WorkspaceGrant { root, subpath: subpath.to_string() })
+                    }
+                    None => {
+                        return Err(Error::InvalidRequest(format!(
+                            "workspace lend `{path}` matches no preopen"
+                        )));
+                    }
+                },
+            };
 
             let wire = completion::Request {
                 model: request.model,
@@ -242,6 +255,59 @@ pub trait Model: Send + Sync {
 
             completion::create(wire).await.map(Into::into).map_err(Into::into)
         }
+    }
+}
+
+/// Resolve a lend path against the guest's preopens: the longest preopen
+/// name that equals the path or prefixes it at a `/` boundary wins; the
+/// remainder becomes the grant's subpath (empty for the mount itself).
+#[cfg(any(target_arch = "wasm32", test))]
+fn resolve_lend<'a, D>(directories: &'a [(D, String)], path: &'a str) -> Option<(&'a D, &'a str)> {
+    directories
+        .iter()
+        .filter_map(|(dir, name)| Some((dir, lend_subpath(name, path)?)))
+        .max_by_key(|(_, subpath)| std::cmp::Reverse(subpath.len()))
+}
+
+/// The subpath of `path` beneath the preopen `name`, when `name` covers it.
+#[cfg(any(target_arch = "wasm32", test))]
+fn lend_subpath<'a>(name: &str, path: &'a str) -> Option<&'a str> {
+    if path == name {
+        return Some("");
+    }
+    path.strip_prefix(name)?.strip_prefix('/').filter(|rest| !rest.is_empty())
+}
+
+// The lend resolution is pure path math that only executes on `wasm32`
+// (preopens exist nowhere else), so it is covered in-process here.
+#[cfg(test)]
+mod tests {
+    use super::resolve_lend;
+
+    fn preopens() -> Vec<((), String)> {
+        vec![((), ".".to_string()), ((), "/emery-workspaces".to_string())]
+    }
+
+    #[test]
+    fn resolves_mount_and_subdirectory() {
+        let dirs = preopens();
+        assert_eq!(resolve_lend(&dirs, ".").map(|(_, sub)| sub), Some(""));
+        assert_eq!(
+            resolve_lend(&dirs, "/emery-workspaces/ws-1").map(|(_, sub)| sub),
+            Some("ws-1")
+        );
+        assert_eq!(
+            resolve_lend(&dirs, "/emery-workspaces/ws-1/nested").map(|(_, sub)| sub),
+            Some("ws-1/nested")
+        );
+    }
+
+    #[test]
+    fn refuses_unmatched_and_lookalike_paths() {
+        let dirs = preopens();
+        assert!(resolve_lend(&dirs, "/elsewhere").is_none());
+        assert!(resolve_lend(&dirs, "/emery-workspaces-evil/x").is_none());
+        assert!(resolve_lend(&dirs, "/emery-workspaces/").is_none());
     }
 }
 

--- a/crates/omnia-guest/src/capabilities/model.rs
+++ b/crates/omnia-guest/src/capabilities/model.rs
@@ -285,8 +285,8 @@ fn lend_subpath<'a>(name: &str, path: &'a str) -> Option<&'a str> {
 mod tests {
     use super::resolve_lend;
 
-    fn preopens() -> Vec<((), String)> {
-        vec![((), ".".to_string()), ((), "/emery-workspaces".to_string())]
+    fn preopens() -> Vec<(u8, String)> {
+        vec![(0, ".".to_string()), (1, "/emery-workspaces".to_string())]
     }
 
     #[test]

--- a/crates/omnia-guest/src/capabilities/model.rs
+++ b/crates/omnia-guest/src/capabilities/model.rs
@@ -229,9 +229,10 @@ pub trait Model: Send + Sync {
             let workspace = match request.workspace.as_deref() {
                 None => None,
                 Some(path) => match resolve_lend(&directories, path) {
-                    Some((root, subpath)) => {
-                        Some(completion::WorkspaceGrant { root, subpath: subpath.to_string() })
-                    }
+                    Some((root, subpath)) => Some(completion::WorkspaceGrant {
+                        root,
+                        subpath: subpath.to_string(),
+                    }),
                     None => {
                         return Err(Error::InvalidRequest(format!(
                             "workspace lend `{path}` matches no preopen"
@@ -292,10 +293,7 @@ mod tests {
     fn resolves_mount_and_subdirectory() {
         let dirs = preopens();
         assert_eq!(resolve_lend(&dirs, ".").map(|(_, sub)| sub), Some(""));
-        assert_eq!(
-            resolve_lend(&dirs, "/emery-workspaces/ws-1").map(|(_, sub)| sub),
-            Some("ws-1")
-        );
+        assert_eq!(resolve_lend(&dirs, "/emery-workspaces/ws-1").map(|(_, sub)| sub), Some("ws-1"));
         assert_eq!(
             resolve_lend(&dirs, "/emery-workspaces/ws-1/nested").map(|(_, sub)| sub),
             Some("ws-1/nested")

--- a/crates/wasi-blobstore/README.md
+++ b/crates/wasi-blobstore/README.md
@@ -10,7 +10,7 @@ Implements the `wasi:blobstore` WIT interface.
 
 - **Default**: In-memory implementation. Data is not persisted across restarts.
 
-- **Production**: [`omnia-azure-blob`](https://github.com/augentic/omnia-backends/tree/main/crates/azure-blob) (Azure Blob Storage), [`omnia-mongodb`](https://github.com/augentic/omnia-backends/tree/main/crates/mongodb) (MongoDB), [`omnia-nats`](https://github.com/augentic/omnia-backends/tree/main/crates/nats) (NATS JetStream object store) — a one-line swap in the host, guests untouched (see the [Production Backends guide](https://github.com/augentic/omnia/blob/main/docs/guides/production-backends.md)).
+- **Production**: [`omnia-azure-blob`](https://github.com/augentic/omnia-backends/tree/main/crates/azure-blob) (Azure Blob Storage), [`omnia-filesystem`](https://github.com/augentic/omnia-backends/tree/main/crates/filesystem) (local filesystem, durable and network-free), [`omnia-mongodb`](https://github.com/augentic/omnia-backends/tree/main/crates/mongodb) (MongoDB), [`omnia-nats`](https://github.com/augentic/omnia-backends/tree/main/crates/nats) (NATS JetStream object store) — a one-line swap in the host, guests untouched (see the [Production Backends guide](https://github.com/augentic/omnia/blob/main/docs/guides/production-backends.md)).
 
 ## Usage
 

--- a/crates/wasi-http/Cargo.toml
+++ b/crates/wasi-http/Cargo.toml
@@ -33,7 +33,7 @@ hyper.workspace = true
 # wasmtime-wasi-http. The default backend installs ring as the process
 # provider before building a client (see `host/default_impl.rs`).
 reqwest = { version = "0.13.4", default-features = false, features = ["http2", "rustls-no-provider", "stream", "system-proxy"] }
-rustls = { version = "0.23.42", default-features = false, features = ["ring", "std"] }
+rustls = { version = "0.23.43", default-features = false, features = ["ring", "std"] }
 tokio = { workspace = true, features = ["time"] }
 wasmtime = { workspace = true, features = ["component-model-async"] }
 wasmtime-wasi.workspace = true

--- a/crates/wasi-model/src/host.rs
+++ b/crates/wasi-model/src/host.rs
@@ -42,7 +42,7 @@ pub use self::gate::validate as validate_request;
 use self::generated::omnia::model::completion;
 pub use self::generated::omnia::model::completion::{
     Effort, Error, Format, Function, Generation, Grants, Mcp, Message, Reply, Request, Role,
-    Schema, Tool,
+    Schema, Tool, WorkspaceGrant,
 };
 pub use self::types::{Answer, DirEntry, Reference, ToolTurn, Transcript, Usage};
 

--- a/crates/wasi-model/src/host/workspace.rs
+++ b/crates/wasi-model/src/host/workspace.rs
@@ -1,10 +1,12 @@
 //! Workspace resolution in the host.
 //!
 //! A guest lends a `wasi:filesystem` workspace through
-//! `grants.workspace: option<borrow<descriptor>>`. This module turns that
-//! borrowed descriptor into an owned, `Send + Sync` [`Workspace`] the backend
-//! can use across `.await` points, *after* proving the lent directory is one the
-//! deployment authorized.
+//! `grants.workspace: option<workspace-grant>` — a borrowed mount-root
+//! descriptor plus a relative subpath. This module turns that grant into an
+//! owned, `Send + Sync` [`Workspace`] the backend can use across `.await`
+//! points, *after* proving the lent root is one the deployment authorized
+//! and reopening the subpath beneath it so the lend can never escape the
+//! mount.
 
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
@@ -16,9 +18,10 @@ use cap_std::fs::Dir;
 use futures::FutureExt as _;
 use omnia::{FutureResult, MountRegistry};
 use tokio::task::spawn_blocking;
-use wasmtime::component::{Resource, ResourceTable};
+use wasmtime::component::ResourceTable;
 use wasmtime_wasi::filesystem::Descriptor;
 
+use super::generated::omnia::model::completion::WorkspaceGrant;
 use super::types::DirEntry;
 
 const MAX_READ_BYTES: u64 = 4 * 1024 * 1024;
@@ -71,28 +74,55 @@ fn ready_err<R: Send + 'static>(err: anyhow::Error) -> FutureResult<R> {
 
 // Resolve a `grants.workspace` into a [`Workspace`].
 pub fn resolve(
-    table: &ResourceTable, registry: &MountRegistry, borrow: Option<&Resource<Descriptor>>,
+    table: &ResourceTable, registry: &MountRegistry, grant: Option<&WorkspaceGrant>,
 ) -> anyhow::Result<Option<Workspace>> {
-    let Some(resource) = borrow else {
+    let Some(grant) = grant else {
         return Ok(None);
     };
 
-    let descriptor = table.get(resource).context("resolving the lent workspace descriptor")?;
+    let descriptor = table.get(&grant.root).context("resolving the lent workspace descriptor")?;
 
     let Descriptor::Dir(dir) = descriptor else {
-        bail!("grants.workspace must be a directory descriptor, not a file");
+        bail!("grants.workspace root must be a directory descriptor, not a file");
     };
 
     let meta = dir.dir.dir_metadata().context("reading lent workspace directory metadata")?;
     let entry = registry
         .match_identity(meta.dev(), meta.ino())
-        .context("lent workspace is not an authorized mount (out of scope)")?;
+        .context("lent workspace root is not an authorized mount (out of scope)")?;
+
+    if grant.subpath.is_empty() {
+        return Ok(Some(Workspace {
+            dir: Arc::clone(&entry.dir),
+            local_path: entry.host_path.clone(),
+            writable: entry.writable(),
+        }));
+    }
+
+    check_subpath(&grant.subpath)?;
+    // cap-std's `open_dir` resolves beneath the verified mount root and
+    // refuses any escape, so the subpath grant inherits the root's authority.
+    let dir = entry
+        .dir
+        .open_dir(&grant.subpath)
+        .with_context(|| format!("opening lent workspace subpath `{}`", grant.subpath))?;
 
     Ok(Some(Workspace {
-        dir: Arc::clone(&entry.dir),
-        local_path: entry.host_path.clone(),
+        dir: Arc::new(dir),
+        local_path: entry.host_path.join(&grant.subpath),
         writable: entry.writable(),
     }))
+}
+
+// Refuse a subpath that is not a plain relative `/`-separated path.
+fn check_subpath(subpath: &str) -> anyhow::Result<()> {
+    let plain = !subpath.starts_with('/')
+        && !subpath.contains('\\')
+        && subpath.split('/').all(|part| !part.is_empty() && part != "." && part != "..");
+    if plain {
+        return Ok(());
+    }
+    bail!("grants.workspace subpath `{subpath}` is not a plain relative path");
 }
 
 fn read_blocking(dir: &Dir, path: &str) -> anyhow::Result<Vec<u8>> {

--- a/crates/wasi-model/wit/model.wit
+++ b/crates/wasi-model/wit/model.wit
@@ -153,15 +153,27 @@ interface completion {
     //     named(string),
     // }
 
+    /// One lent workspace: an authorized mount root plus a relative
+    /// subpath scoping the lend to a directory beneath it.
+    record workspace-grant {
+        /// Typed `wasi:filesystem` capability for bounded `read` / `list` / `write`
+        /// (genai) and the spawned agent's direct access (cursor). A `borrow`, so the
+        /// runtime core never trusts a forgeable integer handle — the host resolves it
+        /// from the resource table exactly as other hosts take typed resources, and
+        /// requires it to be an authorized mount root.
+        root: borrow<descriptor>,
+        /// `/`-separated relative path beneath `root` scoping the lend; empty lends
+        /// the mount root itself. The host reopens it beneath the verified root, so
+        /// the grant can never escape the mount.
+        subpath: string,
+    }
+
     /// Host capabilities lent for this completion; drives host-injected tool injection.
     record grants {
         /// Guest id whose `references` export `resolve` targets.
         references: option<string>,
-        /// Typed `wasi:filesystem` capability for bounded `read` / `list` / `write`
-        /// (genai) and the spawned agent's direct access (cursor). A `borrow`, so the
-        /// The runtime core never trusts a forgeable integer handle — the host resolves it from
-        /// the resource table exactly as other hosts take typed resources.
-        workspace: option<borrow<descriptor>>,
+        /// The workspace lent for this completion.
+        workspace: option<workspace-grant>,
     }
 
     /// Complete models-API-style request for one completion. Guests that want a

--- a/crates/wasi-sql/Cargo.toml
+++ b/crates/wasi-sql/Cargo.toml
@@ -28,7 +28,7 @@ fromenv = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 omnia.workspace = true
 parking_lot = { workspace = true, optional = true }
-rusqlite = { version = "0.40.1", features = ["bundled"], optional = true }
+rusqlite = { version = "0.40.2", features = ["bundled"], optional = true }
 tokio = { workspace = true, features = ["rt"], optional = true }
 wasmtime.workspace = true
 wasmtime-wasi.workspace = true

--- a/examples/conformance/guest.rs
+++ b/examples/conformance/guest.rs
@@ -17,9 +17,7 @@ use bytes::Bytes;
 use omnia_guest::document_store::{
     Document as DocDocument, Filter as DocFilter, QueryOptions as DocQueryOptions, SortField,
 };
-use omnia_guest::{DocumentStore, HttpResult};
-use omnia_wasi_blobstore::blobstore;
-use omnia_wasi_blobstore::types::{IncomingValue, OutgoingValue};
+use omnia_guest::{BlobStore, DocumentStore, HttpResult};
 use omnia_wasi_config::store as config_store;
 use omnia_wasi_identity::credentials::get_identity;
 use omnia_wasi_keyvalue::atomics::{self, Cas, CasError};
@@ -155,44 +153,32 @@ async fn keyvalue_round_trip(
     Ok(Json(json!({ "message": "keyvalue ok" })))
 }
 
-// --- wasi:blobstore (streaming write, then read back) ---
+// --- wasi:blobstore (capability write, then read back) ---
 
 #[derive(Debug, Deserialize)]
 struct BlobstoreParams {
     object: String,
 }
 
+/// The default trait bodies drive the real `wasi:blobstore` imports,
+/// so this route exercises the capability's own streaming (including
+/// the chunked write) rather than hand-rolled bindings calls.
+struct BlobProvider;
+
+impl BlobStore for BlobProvider {}
+
 #[omnia_wasi_otel::instrument]
 async fn blobstore_round_trip(
     Query(p): Query<BlobstoreParams>, body: Bytes,
 ) -> HttpResult<Json<Value>> {
-    let outgoing = OutgoingValue::new_outgoing_value();
-    {
-        let stream = outgoing
-            .outgoing_value_write_body()
-            .await
-            .map_err(|()| anyhow!("failed to create stream"))?;
-        // `blocking-write-and-flush` accepts at most 4096 bytes per call.
-        for chunk in body.chunks(4096) {
-            stream.blocking_write_and_flush(chunk).map_err(|e| anyhow!("writing body: {e}"))?;
-        }
-    }
+    BlobProvider.create_container("container").await.context("failed to create container")?;
+    BlobProvider.put("container", &p.object, &body).await.context("failed to write data")?;
 
-    let container = blobstore::create_container("container".to_string())
+    let data = BlobProvider
+        .get("container", &p.object)
         .await
-        .map_err(|e| anyhow!("failed to create container: {e}"))?;
-    container
-        .write_data(p.object.clone(), &outgoing)
-        .await
-        .map_err(|e| anyhow!("failed to write data: {e}"))?;
-    OutgoingValue::finish(outgoing).map_err(|e| anyhow!("issue finishing: {e}"))?;
-
-    let incoming = container
-        .get_data(p.object.clone(), 0, 0)
-        .await
-        .map_err(|e| anyhow!("failed to read data: {e}"))?;
-    let data = IncomingValue::incoming_value_consume_sync(incoming)
-        .map_err(|e| anyhow!("failed to consume incoming value: {e}"))?;
+        .context("failed to read data")?
+        .ok_or_else(|| anyhow!("object missing after write"))?;
     if data != body {
         Err(anyhow!("blob round-trip mismatch"))?;
     }

--- a/examples/model/guest.rs
+++ b/examples/model/guest.rs
@@ -27,11 +27,17 @@ wasip3::cli::command::export!(CliGuest);
 impl Guest for CliGuest {
     async fn run() -> Result<(), ()> {
         // Read the preopen table the host populated from `[[mount]]` and
-        // pick the tree named `.` to lend. `directories` must outlive the
-        // `create` call below — the lent `workspace` borrows one of its
-        // descriptors.
+        // pick the tree named `.` to lend as the grant's root (with an
+        // empty subpath — the mount itself). `directories` must outlive
+        // the `create` call below — the lent `workspace` borrows one of
+        // its descriptors.
         let directories = preopens::get_directories();
-        let workspace = directories.iter().find_map(|(dir, name)| (name == ".").then_some(dir));
+        let workspace = directories.iter().find_map(|(dir, name)| {
+            (name == ".").then_some(completion::WorkspaceGrant {
+                root: dir,
+                subpath: String::new(),
+            })
+        });
 
         let (system, messages) = Sections {
             role: Some("a terse code reviewer".to_string()),

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -30,16 +30,12 @@ criteria = "safe-to-deploy"
 version = "0.8.12"
 criteria = "safe-to-deploy"
 
+[[exemptions.android_system_properties]]
+version = "0.1.6"
+criteria = "safe-to-deploy"
+
 [[exemptions.autocfg]]
 version = "1.5.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.aws-lc-rs]]
-version = "1.17.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.aws-lc-sys]]
-version = "0.43.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.axum]]
@@ -83,7 +79,7 @@ version = "0.6.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.cc]]
-version = "1.4.0"
+version = "1.4.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.chacha20]]
@@ -95,7 +91,7 @@ version = "0.4.45"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_complete]]
-version = "4.6.7"
+version = "4.6.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.combine]]
@@ -183,7 +179,7 @@ version = "6.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.data-encoding]]
-version = "2.11.0"
+version = "2.11.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.deadpool]]
@@ -203,7 +199,7 @@ version = "0.11.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.displaydoc]]
-version = "0.2.6"
+version = "0.2.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.either]]
@@ -219,7 +215,7 @@ version = "0.3.6"
 criteria = "safe-to-run"
 
 [[exemptions.fancy-regex]]
-version = "0.18.0"
+version = "0.19.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.fastrand]]
@@ -227,7 +223,7 @@ version = "2.5.0"
 criteria = "safe-to-run"
 
 [[exemptions.find-msvc-tools]]
-version = "0.1.9"
+version = "0.1.10"
 criteria = "safe-to-deploy"
 
 [[exemptions.fluent-uri]]
@@ -244,10 +240,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.fromenv-derive]]
 version = "0.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.fs_extra]]
-version = "1.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.futures]]
@@ -327,7 +319,7 @@ version = "1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.hybrid-array]]
-version = "0.4.13"
+version = "0.4.14"
 criteria = "safe-to-deploy"
 
 [[exemptions.hyper-rustls]]
@@ -383,7 +375,7 @@ version = "1.48.0"
 criteria = "safe-to-run"
 
 [[exemptions.ipnet]]
-version = "2.12.0"
+version = "2.12.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.itertools]]
@@ -410,24 +402,20 @@ criteria = "safe-to-deploy"
 version = "0.4.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.jobserver]]
-version = "0.1.35"
-criteria = "safe-to-deploy"
-
 [[exemptions.js-sys]]
-version = "0.3.103"
+version = "0.3.104"
 criteria = "safe-to-deploy"
 
 [[exemptions.jsonschema]]
-version = "0.49.1"
+version = "0.49.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.jsonschema-regex]]
-version = "0.49.1"
+version = "0.49.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.jsonschema-value]]
-version = "0.49.1"
+version = "0.49.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.leb128]]
@@ -439,7 +427,7 @@ version = "0.1.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.libsqlite3-sys]]
-version = "0.38.1"
+version = "0.38.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.litemap]]
@@ -515,10 +503,6 @@ version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.opentelemetry]]
-version = "0.32.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.opentelemetry-http]]
 version = "0.32.0"
 criteria = "safe-to-deploy"
 
@@ -631,7 +615,7 @@ version = "0.5.18"
 criteria = "safe-to-deploy"
 
 [[exemptions.referencing]]
-version = "0.49.1"
+version = "0.49.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.ring]]
@@ -643,7 +627,7 @@ version = "0.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.rusqlite]]
-version = "0.40.1"
+version = "0.40.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustc-hash]]
@@ -651,7 +635,7 @@ version = "2.1.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls]]
-version = "0.23.42"
+version = "0.23.43"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls-native-certs]]
@@ -704,10 +688,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.serde_derive]]
 version = "1.0.229"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde_spanned]]
-version = "1.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_urlencoded]]
@@ -791,7 +771,7 @@ version = "0.30.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml]]
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml_writer]]
@@ -839,7 +819,7 @@ version = "0.3.23"
 criteria = "safe-to-deploy"
 
 [[exemptions.trybuild]]
-version = "1.0.118"
+version = "1.0.120"
 criteria = "safe-to-run"
 
 [[exemptions.tungstenite]]
@@ -883,23 +863,23 @@ version = "2.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen]]
-version = "0.2.126"
+version = "0.2.127"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-futures]]
-version = "0.4.76"
+version = "0.4.77"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro]]
-version = "0.2.126"
+version = "0.2.127"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro-support]]
-version = "0.2.126"
+version = "0.2.127"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-shared]]
-version = "0.2.126"
+version = "0.2.127"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-streams]]
@@ -911,7 +891,7 @@ version = "0.6.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.web-sys]]
-version = "0.3.103"
+version = "0.3.104"
 criteria = "safe-to-deploy"
 
 [[exemptions.web-time]]
@@ -943,11 +923,11 @@ version = "0.8.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy]]
-version = "0.8.55"
+version = "0.8.56"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy-derive]]
-version = "0.8.55"
+version = "0.8.56"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerofrom]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -2,8 +2,8 @@
 # cargo-vet imports lock
 
 [[publisher.aho-corasick]]
-version = "1.1.4"
-when = "2025-10-28"
+version = "1.1.5"
+when = "2026-08-03"
 user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
@@ -30,8 +30,8 @@ user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
 [[publisher.async-trait]]
-version = "0.1.91"
-when = "2026-07-18"
+version = "0.1.92"
+when = "2026-08-08"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -72,15 +72,15 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.clap]]
-version = "4.6.4"
-when = "2026-07-21"
+version = "4.6.6"
+when = "2026-08-06"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.clap_builder]]
-version = "4.6.2"
-when = "2026-07-15"
+version = "4.6.6"
+when = "2026-08-06"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
@@ -98,12 +98,6 @@ when = "2026-03-12"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
-
-[[publisher.cmake]]
-version = "0.1.58"
-when = "2026-03-26"
-user-id = 55123
-user-login = "rust-lang-owner"
 
 [[publisher.core-foundation]]
 version = "0.9.3"
@@ -218,8 +212,8 @@ user-id = 55123
 user-login = "rust-lang-owner"
 
 [[publisher.http]]
-version = "1.4.2"
-when = "2026-06-08"
+version = "1.5.0"
+when = "2026-07-29"
 user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
@@ -422,8 +416,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.regex-automata]]
-version = "0.4.16"
-when = "2026-07-15"
+version = "0.4.18"
+when = "2026-08-04"
 user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
@@ -561,8 +555,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.thiserror]]
-version = "2.0.19"
-when = "2026-07-18"
+version = "2.0.20"
+when = "2026-08-08"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -575,8 +569,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.thiserror-impl]]
-version = "2.0.19"
-when = "2026-07-18"
+version = "2.0.20"
+when = "2026-08-08"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -589,8 +583,8 @@ user-login = "Darksonn"
 user-name = "Alice Ryhl"
 
 [[publisher.tokio-macros]]
-version = "2.7.1"
-when = "2026-07-17"
+version = "2.7.2"
+when = "2026-07-29"
 user-id = 6741
 user-login = "Darksonn"
 user-name = "Alice Ryhl"
@@ -610,8 +604,8 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.toml_parser]]
-version = "1.1.2+spec-1.1.0"
-when = "2026-04-01"
+version = "1.1.3+spec-1.1.0"
+when = "2026-07-27"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
@@ -1848,13 +1842,6 @@ criteria = "safe-to-deploy"
 version = "0.1.0"
 notes = "No unsafe usage or ambient capabilities, sane build script"
 
-[[audits.google.audits.android_system_properties]]
-who = "Manish Goregaokar <manishearth@google.com>"
-criteria = "safe-to-deploy"
-version = "0.1.5"
-notes = "Android system API FFI"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
 [[audits.google.audits.base64]]
 who = "amarjotgill <amarjotgill@google.com>"
 criteria = "safe-to-deploy"
@@ -2312,6 +2299,20 @@ information for parsing version information.
 """
 aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.serde_spanned]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "1.0.3"
+notes = "Relatively simple Serde trait implementations.  No IO or unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.serde_spanned]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.3 -> 1.1.1"
+notes = "No code changes, just dependency updates."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.sha2]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
@@ -2391,16 +2392,6 @@ criteria = "safe-to-deploy"
 delta = "0.10.3 -> 0.10.4"
 notes = "Adds panics to prevent a block size of zero from causing unsoundness."
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.dunce]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-version = "1.0.5"
-notes = """
-Does what it says on the tin. No `unsafe`, and the only IO is `std::fs::canonicalize`.
-Path and string handling looks plausibly correct.
-"""
-aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
 [[audits.zcash.audits.generic-array]]
 who = "Sean Bowe <ewillbefull@gmail.com>"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the model completion ABI and filesystem lend resolution (security-sensitive mount scoping); behavior is intentionally stricter but affects all workspace-lending guests.
> 
> **Overview**
> **Workspace lending** for model completion is reworked from a single borrowed directory descriptor (effectively the `"."` preopen) to a **`workspace-grant`** with an authorized **mount root** plus a **relative subpath**, so guests can lend the full mount or a subdirectory without escaping the mount.
> 
> On the **WIT/host** side, `grants.workspace` is now `option<workspace-grant>`. The host verifies the root against authorized mounts, validates the subpath, and reopens it under the root via cap-std. Guest bindings replace `lend_workspace: bool` with **`workspace: Option<String>`**, resolved on wasm32 by longest matching preopen prefix into root + subpath (with unit tests).
> 
> **Blobstore** `put` on wasm32 writes in **4096-byte chunks** to respect the WASI stream write budget. Conformance blob tests use the **`BlobStore`** trait instead of raw bindings.
> 
> The rest is routine **dependency bumps** (`Cargo.toml` / lockfile), **wrpc** git pin refresh, blobstore README noting **omnia-filesystem**, and small example updates for the new grant shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8626994822d672ef86a29a636e8a2e4fb03ee3d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->